### PR TITLE
Build: some enhancements to the run scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ for development/testing, you can call:
 $ npm run-script run
 ```
 
+To include additional flags for a specific run, append them after `--`:
+
+```
+npm run-script run -- -b nightly
+```
+
+To specify flags to use regularly, use `npm config set jpm_runflags`:
+
+```
+npm config set jpm_runflags="-b nightly"
+```
+
 Note of course that the resulting add-on is unsigned, and likely won't work on
 release versions of Firefox. You can flip the `xpinstall.signatures.required`
 preference on other channels accordingly.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "addon"
   ],
   "scripts": {
-    "run": "jpm run --addon-dir dist/",
+    "prerun": "npm run-script build",
+    "run": "jpm run --addon-dir dist/ $npm_config_jpm_runflags",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "git clean -fX .",
     "build": "webpack",


### PR DESCRIPTION
This provides two things:

1. build as a pre-step to running
2. allow for additional configuration to JPM via `npm config`