### PR TITLE
Don't copy extra JS files to the dist dir

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,44 +1,11 @@
-var CopyWebpackPlugin = require("copy-webpack-plugin");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+
 var path = require("path");
 
 var entries = {
   background: "./webextension/background.js",
-  manage: ["babel-polyfill", "./webextension/manage.js"]
+  manage: "./webextension/manage.js"
 };
-
-/**
- * Return a list of files that are part of our source tree (i.e. they start with
- * `./` or `../`.
- *
- * @param files An Array of files or a single file.
- * @return A generator of the filtered files.
- */
-function* filterFiles(files) {
-  if (!Array.isArray(files)) {
-    files = [files];
-  }
-
-  for (let f of files) {
-    if (f.match(/^\.+\//))
-      yield f.replace(/^\.+\//, "");
-  }
-}
-
-/**
- * Chain a sequence of generators together.
- *
- * @param ...generators A sequence of generator objects.
- * @return A generator chaining together all the input generators.
- */
-function* chain(...generators) {
-  for (let g of generators) {
-    yield* g;
-  }
-}
-
-var ignoreOnCopy = [...chain(...Object.values(entries).map(
-  v => filterFiles(v))
-)];
 
 var config = {
   context: path.join(__dirname, "/src"),
@@ -56,7 +23,7 @@ var config = {
         exclude: /node_modules/,
         loader: "babel-loader",
         query: {
-          presets: ["react", "es2015"]
+          presets: ["react"]
         }
       }
     ],
@@ -64,8 +31,14 @@ var config = {
 
   plugins: [
     new CopyWebpackPlugin([
-      {from: "**/*"},
-    ], {ignore: ignoreOnCopy}),
+      {from: "bootstrap.js"},
+      {from: "chrome.manifest"},
+      {from: "install.rdf"},
+      {from: "webextension/manifest.json", to: "webextension/"},
+      {from: "webextension/*.ftl"},
+      {from: "webextension/*.html"},
+      {from: "webextension/icons/*"},
+    ]),
   ],
 };
 module.exports = config;


### PR DESCRIPTION
This switches us to opt-in for copying to dist. That way, we don't
accidentally copy over JS files that are already bundled by WebPack (this was
happening for l10n.js).