### PR TITLE
Fix JPM so a profile can run legacy, unsigned extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,29 @@ Lockbox for Firefox is a work-in-progress extension for Firefox to improve upon
 Firefox's built-in password management. If you're interested, you should
 probably come back later when we have more to show!
 
-## Building
+## Installing
 
-To **build the project**, simply run:
+To **build the project** and install dependencies, simply run:
 
 ```sh
-$ cd lockbox-extension/
-$ npm install
-$ npm run-script build
+npm install
+```
+
+## Building
+
+To **build the project**, simple run:
+
+```sh
+npm run-script build
 ```
 
 This puts all the necessary files in the `dist/` directory, which you can then
 load into Firefox (e.g. `about:debugging`).
 
-If you'd like to **build an .xpi**, you can run:
+If you'd like to **build an extension .xpi**, you can run:
 
 ```sh
-$ npm run-script package
+npm run-script package
 ```
 
 The resulting add-on is unsigned and likely won't work on release versions of
@@ -29,22 +35,24 @@ channels accordingly.
 
 In preparation for 57, legacy extensions are also disabled. So you'll need to flip the `extensions.legacy.enabled` preference, too.
 
+## Quick Start
+
 If you'd like to quickly **start up a new Firefox profile** with Lockbox
 installed for development/testing, you can run:
 
 ```sh
-$ npm run-script run
+npm run-script run
 ```
 
 To include additional flags for a specific run, append them after `--`:
 
-```
+```sh
 npm run-script run -- -b nightly
 ```
 
 To specify flags to use regularly, use `npm config set jpm_runflags`:
 
-```
+```sh
 npm config set jpm_runflags="-b nightly"
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install
 
 ## Building
 
-To **build the project**, simple run:
+To **build the project**, simply run:
 
 ```sh
 npm run-script build

--- a/jpm-prefs.json
+++ b/jpm-prefs.json
@@ -1,0 +1,4 @@
+{
+  "xpinstall.signatures.required": false,
+  "extensions.legacy.enabled": true
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "prerun": "npm run-script build",
-    "run": "jpm run --addon-dir dist/ ${npm_config_jpm_runflags}",
+    "run": "jpm run --addon-dir dist/ ${npm_config_jpm_runflags} --prefs jpm-prefs.json",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "git clean -fX ./dist ./*.xpi",
     "distclean": "git clean -dfX",


### PR DESCRIPTION
Fixes #38 

This adds the two prefs that a new profile would need to actually load our extension now (legacy, unsigned) and pass them to jpm to run.