### PR TITLE
import all exported DataStore symbols

### DIFF
--- a/src/webextension/background/datastore.js
+++ b/src/webextension/background/datastore.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import DataStore from "lockbox-datastore";
+import * as DataStore from "lockbox-datastore";
 
 const datastore = DataStore.create({
   prompts: {unlock: () => ""},


### PR DESCRIPTION
This change works the same while `lockbox-datastore` follows CommonJS or if (when?) it switches to ES6 modules.