### PR TITLE
Rewrite the <CurrentItem/> container

### DIFF
--- a/src/webextension/manage/components/app.css
+++ b/src/webextension/manage/components/app.css
@@ -24,3 +24,7 @@ body {
 .app > article {
   grid-column: 2;
 }
+
+.app > article {
+  margin: 1em;
+}

--- a/src/webextension/manage/components/itemDetails.css
+++ b/src/webextension/manage/components/itemDetails.css
@@ -3,5 +3,4 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .itemDetails {
-  margin: 1em;
 }

--- a/src/webextension/manage/components/itemDetails.js
+++ b/src/webextension/manage/components/itemDetails.js
@@ -8,15 +8,19 @@ import React from "react";
 
 import styles from "./itemDetails.css";
 
+// Note: ItemDetails doesn't directly interact with items from the Lockbox
+// datastore. For that, please consult <../containers/currentItem.js>.
+
 export default class ItemDetails extends React.Component {
   static get propTypes() {
     return {
-      item: PropTypes.shape({
-        id: PropTypes.string.isRequired,
+      fields: PropTypes.shape({
         title: PropTypes.string.isRequired,
         username: PropTypes.string.isRequired,
         password: PropTypes.string.isRequired,
       }),
+      saveLabel: PropTypes.string.isRequired,
+      deleteLabel: PropTypes.string.isRequired,
       onSave: PropTypes.func.isRequired,
       onDelete: PropTypes.func.isRequired,
     };
@@ -24,13 +28,12 @@ export default class ItemDetails extends React.Component {
 
   _setState(props, initial) {
     let state;
-    if (props.item) {
-      state = {...props.item};
+    if (props.fields) {
+      state = {...props.fields};
     } else {
-      state = {id: undefined, title: "", username: "", password: ""};
+      state = {title: "", username: "", password: ""};
     }
 
-    this.newItem = !props.item;
     if (initial) {
       this.state = state;
     } else {
@@ -48,7 +51,7 @@ export default class ItemDetails extends React.Component {
   }
 
   render() {
-    const {onSave, onDelete} = this.props;
+    const {saveLabel, deleteLabel, onSave, onDelete} = this.props;
 
     return (
       <form className={styles.itemDetails} onSubmit={(e) => {
@@ -77,10 +80,10 @@ export default class ItemDetails extends React.Component {
                  onChange={(e) => this.setState({password: e.target.value})}/>
         </p>
         <p>
-          <Localized id={this.newItem ? "save-item" : "update-item"}>
+          <Localized id={saveLabel}>
             <button type="submit" className="browser-style">sAVe</button>
           </Localized>
-          <Localized id={this.newItem ? "cancel-item" : "delete-item"}>
+          <Localized id={deleteLabel}>
             <button type="button" className="browser-style"
                     onClick={(e) => onDelete(this.state.id)}>dELETe</button>
           </Localized>

--- a/src/webextension/manage/containers/currentItem.js
+++ b/src/webextension/manage/containers/currentItem.js
@@ -70,8 +70,8 @@ function UpdateItem({item, onAction}) {
   function onSave(updatedItem) {
     onAction(updateItem(unflattenItem(updatedItem, item.id)));
   }
-  function onDelete(id) {
-    onAction(removeItem(id));
+  function onDelete() {
+    onAction(removeItem(item.id));
   }
 
   return (

--- a/src/webextension/manage/en-US.ftl
+++ b/src/webextension/manage/en-US.ftl
@@ -1,6 +1,9 @@
 add-item = Add Item
 no-item = No item selected
 
+new-item-title = New Item
+update-item-title = Update Item
+
 item-site = Site
 item-username = Username
 item-password = Password

--- a/test/manage/components/app-test.js
+++ b/test/manage/components/app-test.js
@@ -6,7 +6,6 @@ require("babel-polyfill");
 
 import chai, { expect } from "chai";
 import chaiEnzyme from "chai-enzyme";
-import { mount } from "enzyme";
 import React from "react";
 import ReactDOM from "react-dom";
 import configureStore from "redux-mock-store";
@@ -15,7 +14,7 @@ import { Provider } from "react-redux";
 chai.use(chaiEnzyme());
 
 import { initialState } from "../mock-redux-state";
-import MockLocalizationProvider from "../../mock-l10n";
+import mountWithL10n from "../../mock-l10n";
 import App from "../../../src/webextension/manage/components/app";
 import AddItem from "../../../src/webextension/manage/containers/addItem";
 import AllItems from "../../../src/webextension/manage/containers/allItems";
@@ -28,11 +27,9 @@ const mockStore = configureStore(middlewares);
 describe("<App/>", () => {
   it("render app", () => {
     const store = mockStore(initialState);
-    const wrapper = mount(
+    const wrapper = mountWithL10n(
       <Provider store={store}>
-        <MockLocalizationProvider>
-          <App/>
-        </MockLocalizationProvider>
+        <App/>
       </Provider>
     );
 

--- a/test/manage/components/item-test.js
+++ b/test/manage/components/item-test.js
@@ -5,7 +5,6 @@
 require("babel-polyfill");
 
 import chai, { expect } from "chai";
-import { mount } from "enzyme";
 import React from "react";
 import ReactDOM from "react-dom";
 import sinon from "sinon";
@@ -13,7 +12,7 @@ import sinonChai from "sinon-chai";
 
 chai.use(sinonChai);
 
-import MockLocalizationProvider from "../../mock-l10n";
+import mountWithL10n from "../../mock-l10n";
 import Item from "../../../src/webextension/manage/components/item";
 
 describe("<Item/>", () => {
@@ -24,10 +23,8 @@ describe("<Item/>", () => {
   });
 
   it("onClick called", () => {
-    const wrapper = mount(
-      <MockLocalizationProvider>
-        <Item name="title" selected={true} onClick={onClick}/>
-      </MockLocalizationProvider>
+    const wrapper = mountWithL10n(
+      <Item name="title" selected={true} onClick={onClick}/>
     );
     wrapper.simulate("click");
     expect(onClick).to.have.been.calledWith();

--- a/test/manage/components/itemDetails-test.js
+++ b/test/manage/components/itemDetails-test.js
@@ -31,7 +31,8 @@ describe("<ItemDetails/>", () => {
       onDelete = sinon.spy();
       wrapper = mount(
         <MockLocalizationProvider>
-          <ItemDetails onSave={onSave} onDelete={onDelete}/>
+          <ItemDetails saveLabel="save-item" deleteLabel="delete-item"
+                       onSave={onSave} onDelete={onDelete}/>
         </MockLocalizationProvider>
       );
     });
@@ -39,29 +40,27 @@ describe("<ItemDetails/>", () => {
     it("onSave called", () => {
       wrapper.find('button[type="submit"]').simulate("submit");
 
-      const item = {
-        id: undefined,
+      const fields = {
         title: "",
         username: "",
         password: "",
       };
-      expect(onSave).to.have.been.calledWith(item);
+      expect(onSave).to.have.been.calledWith(fields);
     });
 
     it("onSave called after editing", () => {
-      const fields = wrapper.find("input");
-      simulateTyping(fields.at(0), "new title");
-      simulateTyping(fields.at(1), "new username");
-      simulateTyping(fields.at(2), "new password");
+      const formFields = wrapper.find("input");
+      simulateTyping(formFields.at(0), "new title");
+      simulateTyping(formFields.at(1), "new username");
+      simulateTyping(formFields.at(2), "new password");
       wrapper.find('button[type="submit"]').simulate("submit");
 
-      const item = {
-        id: undefined,
+      const fields = {
         title: "new title",
         username: "new username",
         password: "new password",
       };
-      expect(onSave).to.have.been.calledWith(item);
+      expect(onSave).to.have.been.calledWith(fields);
     });
 
     it("onDelete called", () => {
@@ -71,8 +70,7 @@ describe("<ItemDetails/>", () => {
   });
 
   describe("existing item", () => {
-    const item = {
-      id: "0",
+    const fields = {
       title: "title",
       username: "username",
       password: "password",
@@ -83,14 +81,16 @@ describe("<ItemDetails/>", () => {
       onDelete = sinon.spy();
       wrapper = mount(
         <MockLocalizationProvider>
-          <ItemDetails item={item} onSave={onSave} onDelete={onDelete}/>
+          <ItemDetails fields={fields}
+                       saveLabel="save-item" deleteLabel="delete-item"
+                       onSave={onSave} onDelete={onDelete}/>
         </MockLocalizationProvider>
       );
     });
 
     it("onSave called", () => {
       wrapper.find('button[type="submit"]').simulate("submit");
-      expect(onSave).to.have.been.calledWith(item);
+      expect(onSave).to.have.been.calledWith(fields);
     });
 
     it("onSave called after editing", () => {
@@ -100,18 +100,17 @@ describe("<ItemDetails/>", () => {
       simulateTyping(fields.at(2), "new password");
       wrapper.find('button[type="submit"]').simulate("submit");
 
-      const updatedItem = {
-        id: item.id,
+      const updatedFields = {
         title: "new title",
         username: "new username",
         password: "new password",
       };
-      expect(onSave).to.have.been.calledWith(updatedItem);
+      expect(onSave).to.have.been.calledWith(updatedFields);
     });
 
     it("onDelete called", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
-      expect(onDelete).to.have.been.calledWith(item.id);
+      expect(onDelete).to.have.been.calledWith();
     });
   });
 });

--- a/test/manage/components/itemDetails-test.js
+++ b/test/manage/components/itemDetails-test.js
@@ -9,6 +9,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
+import PropTypes from "prop-types";
 
 chai.use(sinonChai);
 
@@ -32,6 +33,13 @@ describe("<ItemDetails/>", () => {
         <ItemDetails saveLabel="save-item" deleteLabel="delete-item"
                      onSave={onSave} onDelete={onDelete}/>
       );
+    });
+
+    it("form fields unfilled", () => {
+      const formFields = wrapper.find("input");
+      expect(formFields.get(0).value).to.equal("");
+      expect(formFields.get(1).value).to.equal("");
+      expect(formFields.get(2).value).to.equal("");
     });
 
     it("onSave called", () => {
@@ -83,29 +91,73 @@ describe("<ItemDetails/>", () => {
       );
     });
 
+    it("form fields filled", () => {
+      const formFields = wrapper.find("input");
+      expect(formFields.get(0).value).to.equal(fields.title);
+      expect(formFields.get(1).value).to.equal(fields.username);
+      expect(formFields.get(2).value).to.equal(fields.password);
+    });
+
     it("onSave called", () => {
       wrapper.find('button[type="submit"]').simulate("submit");
       expect(onSave).to.have.been.calledWith(fields);
     });
 
     it("onSave called after editing", () => {
-      const fields = wrapper.find("input");
-      simulateTyping(fields.at(0), "new title");
-      simulateTyping(fields.at(1), "new username");
-      simulateTyping(fields.at(2), "new password");
-      wrapper.find('button[type="submit"]').simulate("submit");
-
       const updatedFields = {
         title: "new title",
         username: "new username",
         password: "new password",
       };
+
+      const formFields = wrapper.find("input");
+      simulateTyping(formFields.at(0), updatedFields.title);
+      simulateTyping(formFields.at(1), updatedFields.username);
+      simulateTyping(formFields.at(2), updatedFields.password);
+      wrapper.find('button[type="submit"]').simulate("submit");
+
       expect(onSave).to.have.been.calledWith(updatedFields);
     });
 
     it("onDelete called", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
       expect(onDelete).to.have.been.calledWith();
+    });
+  });
+
+  describe("change selected item", () => {
+    const fields = {
+      title: "title",
+      username: "username",
+      password: "password",
+    };
+
+    beforeEach(() => {
+      onSave = sinon.spy();
+      onDelete = sinon.spy();
+      wrapper = mountWithL10n(
+        <ItemDetails fields={fields}
+                     saveLabel="save-item" deleteLabel="delete-item"
+                     onSave={onSave} onDelete={onDelete}/>
+      );
+    });
+
+    it("form fields updated", () => {
+      const formFields = wrapper.find("input");
+      expect(formFields.get(0).value).to.equal(fields.title);
+      expect(formFields.get(1).value).to.equal(fields.username);
+      expect(formFields.get(2).value).to.equal(fields.password);
+
+      const updatedFields = {
+        title: "new title",
+        username: "new username",
+        password: "new password",
+      };
+
+      wrapper.setProps({fields: updatedFields});
+      expect(formFields.get(0).value).to.equal(updatedFields.title);
+      expect(formFields.get(1).value).to.equal(updatedFields.username);
+      expect(formFields.get(2).value).to.equal(updatedFields.password);
     });
   });
 });

--- a/test/manage/components/itemDetails-test.js
+++ b/test/manage/components/itemDetails-test.js
@@ -5,7 +5,6 @@
 require("babel-polyfill");
 
 import chai, { expect } from "chai";
-import { mount } from "enzyme";
 import React from "react";
 import ReactDOM from "react-dom";
 import sinon from "sinon";
@@ -13,7 +12,7 @@ import sinonChai from "sinon-chai";
 
 chai.use(sinonChai);
 
-import MockLocalizationProvider from "../../mock-l10n";
+import mountWithL10n from "../../mock-l10n";
 import ItemDetails from
        "../../../src/webextension/manage/components/itemDetails";
 
@@ -29,11 +28,9 @@ describe("<ItemDetails/>", () => {
     beforeEach(() => {
       onSave = sinon.spy();
       onDelete = sinon.spy();
-      wrapper = mount(
-        <MockLocalizationProvider>
-          <ItemDetails saveLabel="save-item" deleteLabel="delete-item"
-                       onSave={onSave} onDelete={onDelete}/>
-        </MockLocalizationProvider>
+      wrapper = mountWithL10n(
+        <ItemDetails saveLabel="save-item" deleteLabel="delete-item"
+                     onSave={onSave} onDelete={onDelete}/>
       );
     });
 
@@ -79,12 +76,10 @@ describe("<ItemDetails/>", () => {
     beforeEach(() => {
       onSave = sinon.spy();
       onDelete = sinon.spy();
-      wrapper = mount(
-        <MockLocalizationProvider>
-          <ItemDetails fields={fields}
-                       saveLabel="save-item" deleteLabel="delete-item"
-                       onSave={onSave} onDelete={onDelete}/>
-        </MockLocalizationProvider>
+      wrapper = mountWithL10n(
+        <ItemDetails fields={fields}
+                     saveLabel="save-item" deleteLabel="delete-item"
+                     onSave={onSave} onDelete={onDelete}/>
       );
     });
 

--- a/test/manage/components/itemList-test.js
+++ b/test/manage/components/itemList-test.js
@@ -5,7 +5,6 @@
 require("babel-polyfill");
 
 import chai, { expect } from "chai";
-import { mount } from "enzyme";
 import React from "react";
 import ReactDOM from "react-dom";
 import sinon from "sinon";
@@ -13,7 +12,7 @@ import sinonChai from "sinon-chai";
 
 chai.use(sinonChai);
 
-import MockLocalizationProvider from "../../mock-l10n";
+import mountWithL10n from "../../mock-l10n";
 import Item from "../../../src/webextension/manage/components/item";
 import ItemList from "../../../src/webextension/manage/components/itemList";
 
@@ -27,11 +26,9 @@ describe("<ItemList/>", () => {
 
   beforeEach(() => {
     onItemClick = sinon.spy();
-    wrapper = mount(
-      <MockLocalizationProvider>
-        <ItemList items={items} selected={items[0].id}
-                  onItemClick={onItemClick}/>
-      </MockLocalizationProvider>
+    wrapper = mountWithL10n(
+      <ItemList items={items} selected={items[0].id}
+                onItemClick={onItemClick}/>
     );
   });
 

--- a/test/manage/containers/addItem-test.js
+++ b/test/manage/containers/addItem-test.js
@@ -5,14 +5,13 @@
 require("babel-polyfill");
 
 import { expect } from "chai";
-import { mount } from "enzyme";
 import React from "react";
 import ReactDOM from "react-dom";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 
 import { initialState } from "../mock-redux-state";
-import MockLocalizationProvider from "../../mock-l10n";
+import mountWithL10n from "../../mock-l10n";
 import AddItem from "../../../src/webextension/manage/containers/addItem";
 import { startNewItem } from "../../../src/webextension/manage/actions";
 
@@ -22,11 +21,9 @@ const mockStore = configureStore(middlewares);
 describe("<AddItem/>", () => {
   it("START_NEW_ITEM dispatched", () => {
     const store = mockStore(initialState);
-    const wrapper = mount(
+    const wrapper = mountWithL10n(
       <Provider store={store}>
-        <MockLocalizationProvider>
-          <AddItem/>
-        </MockLocalizationProvider>
+        <AddItem/>
       </Provider>
     );
     wrapper.simulate("click");

--- a/test/manage/containers/allItems-test.js
+++ b/test/manage/containers/allItems-test.js
@@ -5,7 +5,6 @@
 require("babel-polyfill");
 
 import { expect } from "chai";
-import { mount } from "enzyme";
 import React from "react";
 import ReactDOM from "react-dom";
 import configureStore from "redux-mock-store";
@@ -13,7 +12,7 @@ import { Provider } from "react-redux";
 import thunk from "redux-thunk";
 
 import { initialState, filledState } from "../mock-redux-state";
-import MockLocalizationProvider from "../../mock-l10n";
+import mountWithL10n from "../../mock-l10n";
 import Item from "../../../src/webextension/manage/components/item";
 import AllItems from "../../../src/webextension/manage/containers/allItems";
 import { SELECT_ITEM_STARTING } from "../../../src/webextension/manage/actions";
@@ -27,11 +26,9 @@ describe("<AllItems/>", () => {
 
     beforeEach(() => {
       store = mockStore(initialState);
-      wrapper = mount(
+      wrapper = mountWithL10n(
         <Provider store={store}>
-          <MockLocalizationProvider>
-            <AllItems/>
-          </MockLocalizationProvider>
+          <AllItems/>
         </Provider>
       );
     });
@@ -46,11 +43,9 @@ describe("<AllItems/>", () => {
 
     beforeEach(() => {
       store = mockStore(filledState);
-      wrapper = mount(
+      wrapper = mountWithL10n(
         <Provider store={store}>
-          <MockLocalizationProvider>
-            <AllItems/>
-          </MockLocalizationProvider>
+          <AllItems/>
         </Provider>
       );
     });

--- a/test/manage/containers/allItems-test.js
+++ b/test/manage/containers/allItems-test.js
@@ -58,8 +58,8 @@ describe("<AllItems/>", () => {
     it("render items", () => {
       expect(wrapper.find(Item)).to.have.length(3);
       expect(wrapper.find(Item).filterWhere(
-        (x) => x.props()["selected"]
-      ).props()["name"]).to.equal(filledState.cache.currentItem.title);
+        (x) => x.prop("selected")
+      ).prop("name")).to.equal(filledState.cache.currentItem.title);
     });
 
     it("SELECT_ITEM dispatched", () => {

--- a/test/manage/containers/currentItem-test.js
+++ b/test/manage/containers/currentItem-test.js
@@ -5,7 +5,6 @@
 require("babel-polyfill");
 
 import chai, { expect } from "chai";
-import { mount } from "enzyme";
 import React from "react";
 import ReactDOM from "react-dom";
 import configureStore from "redux-mock-store";
@@ -13,7 +12,7 @@ import { Provider } from "react-redux";
 import thunk from "redux-thunk";
 
 import { initialState, filledState } from "../mock-redux-state";
-import MockLocalizationProvider from "../../mock-l10n";
+import mountWithL10n from "../../mock-l10n";
 import ItemDetails from
        "../../../src/webextension/manage/components/itemDetails";
 import CurrentItem from
@@ -32,11 +31,9 @@ describe("<CurrentItem/>", () => {
 
     beforeEach(() => {
       store = mockStore(initialState);
-      wrapper = mount(
+      wrapper = mountWithL10n(
         <Provider store={store}>
-          <MockLocalizationProvider>
-            <CurrentItem/>
-          </MockLocalizationProvider>
+          <CurrentItem/>
         </Provider>
       );
     });
@@ -54,11 +51,9 @@ describe("<CurrentItem/>", () => {
       store = mockStore({...filledState, ui: {
         ...filledState.ui, newItem: true
       }});
-      wrapper = mount(
+      wrapper = mountWithL10n(
         <Provider store={store}>
-          <MockLocalizationProvider>
-            <CurrentItem/>
-          </MockLocalizationProvider>
+          <CurrentItem/>
         </Provider>
       );
     });
@@ -85,11 +80,9 @@ describe("<CurrentItem/>", () => {
 
     beforeEach(() => {
       store = mockStore(filledState);
-      wrapper = mount(
+      wrapper = mountWithL10n(
         <Provider store={store}>
-          <MockLocalizationProvider>
-            <CurrentItem/>
-          </MockLocalizationProvider>
+          <CurrentItem/>
         </Provider>
       );
     });

--- a/test/manage/containers/currentItem-test.js
+++ b/test/manage/containers/currentItem-test.js
@@ -17,9 +17,7 @@ import ItemDetails from
        "../../../src/webextension/manage/components/itemDetails";
 import CurrentItem from
        "../../../src/webextension/manage/containers/currentItem";
-import {
-  ADD_ITEM_STARTING, CANCEL_NEW_ITEM, UPDATE_ITEM_STARTING, REMOVE_ITEM_STARTING
-} from "../../../src/webextension/manage/actions";
+import * as actions from "../../../src/webextension/manage/actions";
 
 
 const middlewares = [thunk];
@@ -66,12 +64,25 @@ describe("<CurrentItem/>", () => {
 
     it("ADD_ITEM dispatched", () => {
       wrapper.find('button[type="submit"]').simulate("submit");
-      expect(store.getActions()[0].type).to.equal(ADD_ITEM_STARTING);
+      expect(store.getActions()[0]).to.deep.include({
+        type: actions.ADD_ITEM_STARTING,
+        item: {
+          title: "",
+          id: undefined,
+          entry: {
+            kind: "login",
+            password: "",
+            username: "",
+          },
+        }
+      });
     });
 
     it("CANCEL_NEW_ITEM dispatched", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
-      expect(store.getActions()[0].type).to.equal(CANCEL_NEW_ITEM);
+      expect(store.getActions()[0]).to.deep.equal({
+        type: actions.CANCEL_NEW_ITEM,
+      });
     });
   });
 
@@ -100,12 +111,26 @@ describe("<CurrentItem/>", () => {
 
     it("UPDATE_ITEM dispatched", () => {
       wrapper.find('button[type="submit"]').simulate("submit");
-      expect(store.getActions()[0].type).to.equal(UPDATE_ITEM_STARTING);
+      expect(store.getActions()[0]).to.deep.include({
+        type: actions.UPDATE_ITEM_STARTING,
+        item: {
+          title: "title 1",
+          id: "1",
+          entry: {
+            kind: "login",
+            password: "password 1",
+            username: "username 1",
+          },
+        },
+      });
     });
 
     it("REMOVE_ITEM dispatched", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
-      expect(store.getActions()[0].type).to.equal(REMOVE_ITEM_STARTING);
+      expect(store.getActions()[0]).to.deep.include({
+        type: actions.REMOVE_ITEM_STARTING,
+        id: "1",
+      });
     });
   });
 });

--- a/test/manage/containers/currentItem-test.js
+++ b/test/manage/containers/currentItem-test.js
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import chai, { expect } from "chai";
+import { mount } from "enzyme";
+import React from "react";
+import ReactDOM from "react-dom";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import thunk from "redux-thunk";
+
+import { initialState, filledState } from "../mock-redux-state";
+import MockLocalizationProvider from "../../mock-l10n";
+import ItemDetails from
+       "../../../src/webextension/manage/components/itemDetails";
+import CurrentItem from
+       "../../../src/webextension/manage/containers/currentItem";
+import {
+  ADD_ITEM_STARTING, CANCEL_NEW_ITEM, UPDATE_ITEM_STARTING, REMOVE_ITEM_STARTING
+} from "../../../src/webextension/manage/actions";
+
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe("<CurrentItem/>", () => {
+  describe("nothing selected", () => {
+    let store, wrapper;
+
+    beforeEach(() => {
+      store = mockStore(initialState);
+      wrapper = mount(
+        <Provider store={store}>
+          <MockLocalizationProvider>
+            <CurrentItem/>
+          </MockLocalizationProvider>
+        </Provider>
+      );
+    });
+
+    it("render item", () => {
+      expect(wrapper.text()).to.equal("no iTEm sELECTEd");
+    });
+  });
+
+
+  describe("new item", () => {
+    let store, wrapper;
+
+    beforeEach(() => {
+      store = mockStore({...filledState, ui: {
+        ...filledState.ui, newItem: true
+      }});
+      wrapper = mount(
+        <Provider store={store}>
+          <MockLocalizationProvider>
+            <CurrentItem/>
+          </MockLocalizationProvider>
+        </Provider>
+      );
+    });
+
+    it("render item", () => {
+      const details = wrapper.find(ItemDetails);
+      expect(details).to.have.length(1);
+      expect(details.prop("fields")).to.equal(undefined);
+    });
+
+    it("ADD_ITEM dispatched", () => {
+      wrapper.find('button[type="submit"]').simulate("submit");
+      expect(store.getActions()[0].type).to.equal(ADD_ITEM_STARTING);
+    });
+
+    it("CANCEL_NEW_ITEM dispatched", () => {
+      wrapper.find("button").not('[type="submit"]').simulate("click");
+      expect(store.getActions()[0].type).to.equal(CANCEL_NEW_ITEM);
+    });
+  });
+
+  describe("item selected", () => {
+    let store, wrapper;
+
+    beforeEach(() => {
+      store = mockStore(filledState);
+      wrapper = mount(
+        <Provider store={store}>
+          <MockLocalizationProvider>
+            <CurrentItem/>
+          </MockLocalizationProvider>
+        </Provider>
+      );
+    });
+
+    it("render item", () => {
+      const details = wrapper.find(ItemDetails);
+      const currentItem = filledState.cache.currentItem;
+      expect(details).to.have.length(1);
+      expect(details.prop("fields")).to.deep.equal({
+        title: currentItem.title,
+        username: currentItem.entry.username,
+        password: currentItem.entry.password,
+      });
+    });
+
+    it("UPDATE_ITEM dispatched", () => {
+      wrapper.find('button[type="submit"]').simulate("submit");
+      expect(store.getActions()[0].type).to.equal(UPDATE_ITEM_STARTING);
+    });
+
+    it("REMOVE_ITEM dispatched", () => {
+      wrapper.find("button").not('[type="submit"]').simulate("click");
+      expect(store.getActions()[0].type).to.equal(REMOVE_ITEM_STARTING);
+    });
+  });
+});

--- a/test/manage/mock-redux-state.js
+++ b/test/manage/mock-redux-state.js
@@ -22,11 +22,17 @@ export const filledState = {
       {id: "1", title: "title 1"},
       {id: "2", title: "title 2"},
     ],
-    currentItem: {id: "1", title: "title 1"},
+    currentItem: {
+      id: "1",
+      title: "title 1",
+      entry: {
+        username: "username 1",
+        password: "password 1",
+      },
+    },
     pendingAdd: null,
   },
   ui: {
     newItem: false,
   },
 };
-

--- a/test/mock-l10n.js
+++ b/test/mock-l10n.js
@@ -2,17 +2,37 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { mount } from "enzyme";
+import PropTypes from "prop-types";
 import React from "react";
 import { MessageContext } from "fluent/compat";
-import { LocalizationProvider } from "fluent-react/compat";
+import {
+  LocalizationProvider, ReactLocalization, isReactLocalization
+} from "fluent-react/compat";
 
 function *generateMessages() {
   const context = new MessageContext("en-US");
   yield context;
 }
 
-export default function MockLocalizationProvider(props) {
+export function MockLocalizationProvider(props) {
   return (
     <LocalizationProvider messages={generateMessages()} {...props}/>
   );
+}
+
+export function MockLocalizationContext() {
+  return new ReactLocalization(generateMessages());
+}
+
+export default function mountWithL10n(node, options = {}) {
+  return mount(node, {
+    context: {
+      l10n: MockLocalizationContext(),
+    },
+    childContextTypes: {
+      l10n: isReactLocalization,
+    },
+    ...options
+  });
 }

--- a/test/setup.js
+++ b/test/setup.js
@@ -8,10 +8,16 @@ var jsdom = require("jsdom");
 const { JSDOM } = jsdom;
 const { document } = (new JSDOM("")).window;
 
-global.document = document;
+var exposedProperties = ["window", "navigator", "document", "browser",
+                         "HTMLElement"];
 
-var exposedProperties = ["window", "navigator", "document", "browser"];
+global.document = document;
 global.window = document.defaultView;
+
+// This is necessary for chai's .include() to work due to its dependency on
+// `type-detect`. See <https://github.com/chaijs/type-detect/issues/98>.
+global.HTMLElement = global.window.HTMLElement;
+
 Object.keys(document.defaultView).forEach((property) => {
   if (typeof global[property] === "undefined") {
     exposedProperties.push(property);


### PR DESCRIPTION
This PR rewrites a bunch of the logic in `<CurrentItem/>` so that we don't have the same conditionals all over. Hopefully it'll be more maintainable now. I also added tests for `<CurrentItem/>` plus one case I missed earlier for `<ItemDetails/>`.

Resolves #48.