### PR TITLE
Add tests for Redux-specific bits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2428,6 +2428,15 @@
         "type-detect": "4.0.3"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "1.0.2"
+      }
+    },
     "chai-enzyme": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-0.8.0.tgz",
@@ -11555,12 +11564,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -11571,6 +11574,12 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringify-object": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "addon"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.js\" --ignore-pattern '!.eslintrc.js' .eslintrc.js",
+    "lint": "eslint src test --ignore-pattern '!.eslintrc.js' .eslintrc.js",
     "prebuild": "npm run-script lint",
     "build": "webpack",
     "prerun": "npm run-script build",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.1",
+    "chai-as-promised": "^7.1.1",
     "chai-enzyme": "^0.8.0",
     "copy-webpack-plugin": "^4.0.1",
     "coveralls": "^2.13.1",

--- a/src/webextension/background/datastore.js
+++ b/src/webextension/background/datastore.js
@@ -4,8 +4,6 @@
 
 import DataStore from "lockbox-datastore";
 
-const datastore = DataStore.create({
-  prompts: {unlock: () => ""},
-});
+const datastore = DataStore.create({});
 
 export default datastore;

--- a/src/webextension/background/index.js
+++ b/src/webextension/background/index.js
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import datastore from "./datastore";
-import "./messagePorts";
+import initializeMessagePorts from "./messagePorts";
 
 // XXX: For now, initialize the datastore on startup and then hook up the
 // button. Eventually, we'll have UX to create new datastores (and persist
 // existing ones).
 datastore.initialize().then(() => {
+  initializeMessagePorts();
   function openLockbox() {
     if (datastore.opened) {
       // do something?

--- a/src/webextension/background/messagePorts.js
+++ b/src/webextension/background/messagePorts.js
@@ -6,46 +6,46 @@ import datastore from "./datastore";
 import { makeItemSummary } from "../common";
 
 const ports = new Set();
-browser.runtime.onConnect.addListener((port) => {
-  ports.add(port);
-  port.onDisconnect.addListener(() => {
-    console.log("message port disconnected");
-    ports.delete(port);
-  });
-});
 
-function broadcast(message, excludeSender = null) {
+function broadcast(message, excludedSender) {
   for (let p of ports) {
-    if (!excludeSender || p.sender.contextId !== excludeSender.contextId) {
+    if (!excludedSender || p.sender.contextId !== excludedSender.contextId) {
       p.postMessage(message);
     }
   }
 }
 
-browser.runtime.onMessage.addListener(async function(message, sender) {
-  switch (message.type) {
-  case "add_item": {
-    await datastore.unlock();
-    const item = await datastore.add(message.item);
-    broadcast({type: "added_item", item}, sender);
-    return {item};
-  }
-  case "update_item": {
-    await datastore.unlock();
-    const item = await datastore.update(message.item);
-    broadcast({type: "updated_item", item}, sender);
-    return {item};
-  }
-  case "remove_item":
-    await datastore.remove(message.id);
-    broadcast({type: "removed_item", id: message.id}, sender);
-    return {};
-  case "get_item":
-    return {item: await datastore.get(message.id)};
-  case "list_items":
-    return {items: Array.from((await datastore.list()).values(),
-                              makeItemSummary)};
-  default:
-    return null;
-  }
-});
+export default function initializeMessagePorts() {
+  browser.runtime.onConnect.addListener((port) => {
+    ports.add(port);
+    port.onDisconnect.addListener(() => ports.delete(port));
+  });
+
+  browser.runtime.onMessage.addListener(async function(message, sender) {
+    switch (message.type) {
+    case "list_items":
+      return {items: Array.from((await datastore.list()).values(),
+                                makeItemSummary)};
+    case "add_item": {
+      await datastore.unlock();
+      const item = await datastore.add(message.item);
+      broadcast({type: "added_item", item}, sender);
+      return {item};
+    }
+    case "update_item": {
+      await datastore.unlock();
+      const item = await datastore.update(message.item);
+      broadcast({type: "updated_item", item}, sender);
+      return {item};
+    }
+    case "remove_item":
+      await datastore.remove(message.id);
+      broadcast({type: "removed_item", id: message.id}, sender);
+      return {};
+    case "get_item":
+      return {item: await datastore.get(message.id)};
+    default:
+      throw new Error(`unknown message type "${message.type}`);
+    }
+  });
+}

--- a/src/webextension/manage/index.js
+++ b/src/webextension/manage/index.js
@@ -10,28 +10,13 @@ import thunk from "redux-thunk";
 
 import { AppLocalizationProvider } from "./l10n";
 import App from "./components/app";
-import { listItems, addedItem, updatedItem, removedItem } from "./actions";
+import { listItems } from "./actions";
 import reducer from "./reducers";
+import initializeMessagePorts from "./messagePorts";
 
 const store = createStore(reducer, undefined, applyMiddleware(thunk));
 store.dispatch(listItems());
-
-// Listen for changes to the datastore from other sources and dispatch actions
-// to sync those changes with our Redux store.
-const messagePort = browser.runtime.connect();
-messagePort.onMessage.addListener((message) => {
-  switch (message.type) {
-  case "added_item":
-    store.dispatch(addedItem(message.item));
-    break;
-  case "updated_item":
-    store.dispatch(updatedItem(message.item));
-    break;
-  case "removed_item":
-    store.dispatch(removedItem(message.id));
-    break;
-  }
-});
+initializeMessagePorts(store);
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/webextension/manage/index.js
+++ b/src/webextension/manage/index.js
@@ -11,7 +11,7 @@ import thunk from "redux-thunk";
 import { AppLocalizationProvider } from "./l10n";
 import App from "./components/app";
 import { listItems, addedItem, updatedItem, removedItem } from "./actions";
-import { reducer } from "./reducers";
+import reducer from "./reducers";
 
 const store = createStore(reducer, undefined, applyMiddleware(thunk));
 store.dispatch(listItems());

--- a/src/webextension/manage/messagePorts.js
+++ b/src/webextension/manage/messagePorts.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { addedItem, updatedItem, removedItem } from "./actions";
+
+let messagePort;
+
+export default function initializeMessagePorts(store) {
+  // Listen for changes to the datastore from other sources and dispatch actions
+  // to sync those changes with our Redux store.
+  messagePort = browser.runtime.connect();
+  messagePort.onMessage.addListener((message) => {
+    switch (message.type) {
+    case "added_item":
+      store.dispatch(addedItem(message.item));
+      break;
+    case "updated_item":
+      store.dispatch(updatedItem(message.item));
+      break;
+    case "removed_item":
+      store.dispatch(removedItem(message.id));
+      break;
+    }
+  });
+}

--- a/src/webextension/manage/reducers.js
+++ b/src/webextension/manage/reducers.js
@@ -32,7 +32,7 @@ function maybeRemoveCurrentItem(state, action) {
   return {};
 }
 
-function cacheReducer(state = {
+export function cacheReducer(state = {
   items: [], currentItem: null, pendingAdd: null
 }, action) {
   switch (action.type) {
@@ -76,7 +76,7 @@ function cacheReducer(state = {
   }
 }
 
-function uiReducer(state = {newItem: false}, action) {
+export function uiReducer(state = {newItem: false}, action) {
   switch (action.type) {
   case START_NEW_ITEM:
     return {...state, newItem: true};
@@ -89,7 +89,9 @@ function uiReducer(state = {newItem: false}, action) {
   }
 }
 
-export const reducer = combineReducers({
+const reducer = combineReducers({
   cache: cacheReducer,
   ui: uiReducer,
 });
+
+export default reducer;

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "extends": "../.eslintrc.js"
+}

--- a/test/background/messagePorts-test.js
+++ b/test/background/messagePorts-test.js
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+import datastore from "../../src/webextension/background/datastore";
+import initializeMessagePorts from
+       "../../src/webextension/background/messagePorts";
+
+describe("message ports", () => {
+  let itemId, selfMessagePort, otherMessagePort, selfListener, otherListener;
+
+  before(async() => {
+    await datastore.initialize();
+    initializeMessagePorts();
+
+    selfMessagePort = browser.runtime.connect();
+    otherMessagePort = browser.runtime.connect(undefined, {mockPrimary: false});
+  });
+
+  beforeEach(() => {
+    selfMessagePort.onMessage.addListener(selfListener = sinon.spy());
+    otherMessagePort.onMessage.addListener(otherListener = sinon.spy());
+  });
+
+  afterEach(() => {
+    selfMessagePort.onMessage.mockClearListener();
+    otherMessagePort.onMessage.mockClearListener();
+  });
+
+  after(() => {
+    // Clear the listener set in <src/webextension/background/messagePorts.js>.
+    browser.runtime.onMessage.mockClearListener();
+  });
+
+  it('handle "add_item"', async() => {
+    const item = {
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+    const result = await browser.runtime.sendMessage({
+      type: "add_item",
+      item,
+    });
+    itemId = result.item.id;
+
+    expect(result.item).to.deep.include(item);
+    expect(selfListener).to.have.callCount(0);
+    expect(otherListener).to.have.callCount(1);
+    expect(otherListener.args[0][0].type).to.equal("added_item");
+    expect(otherListener.args[0][0].item).to.deep.include(item);
+  });
+
+  it('handle "update_item"', async() => {
+    const item = {
+      title: "updated title",
+      id: itemId,
+      entry: {
+        kind: "login",
+        username: "updated username",
+        password: "updated password",
+      }
+    };
+    const result = await browser.runtime.sendMessage({
+      type: "update_item",
+      item,
+    });
+
+    expect(result.item).to.deep.include(item);
+    expect(selfListener).to.have.callCount(0);
+    expect(otherListener).to.have.callCount(1);
+    expect(otherListener.args[0][0].type).to.equal("updated_item");
+    expect(otherListener.args[0][0].item).to.deep.include(item);
+  });
+
+  it('handle "get_item"', async() => {
+    const result = await browser.runtime.sendMessage({
+      type: "get_item",
+      id: itemId,
+    });
+
+    expect(result.item).to.deep.include({
+      title: "updated title",
+      entry: {
+        kind: "login",
+        username: "updated username",
+        password: "updated password",
+      },
+    });
+  });
+
+  it('handle "list_items"', async() => {
+    const result = await browser.runtime.sendMessage({
+      type: "list_items",
+    });
+
+    expect(result).to.deep.equal({items: [
+      {id: itemId, title: "updated title"},
+    ]});
+  });
+
+  it('handle "remove_item"', async() => {
+    const result = await browser.runtime.sendMessage({
+      type: "remove_item",
+      id: itemId,
+    });
+
+    expect(result).to.deep.equal({});
+    expect(selfListener).to.have.callCount(0);
+    expect(otherListener).to.have.callCount(1);
+    expect(otherListener).to.be.calledWith({
+      type: "removed_item",
+      id: itemId,
+    });
+  });
+
+  it("handle unknown message type", async() => {
+    await expect(browser.runtime.sendMessage({
+      type: "nonexist",
+    })).to.be.rejectedWith(Error);
+  });
+
+  it("handle message port disconnect", async() => {
+    otherMessagePort.disconnect();
+
+    // Make sure no message is broadcast now that we've disconnected.
+    const item = {
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+    await browser.runtime.sendMessage({
+      type: "add_item",
+      item,
+    });
+    expect(otherListener).to.have.callCount(0);
+  });
+});

--- a/test/background/messagePorts-test.js
+++ b/test/background/messagePorts-test.js
@@ -16,7 +16,7 @@ import datastore from "../../src/webextension/background/datastore";
 import initializeMessagePorts from
        "../../src/webextension/background/messagePorts";
 
-describe("message ports", () => {
+describe("message ports (background side)", () => {
   let itemId, selfMessagePort, otherMessagePort, selfListener, otherListener;
 
   before(async() => {
@@ -38,7 +38,8 @@ describe("message ports", () => {
   });
 
   after(() => {
-    // Clear the listener set in <src/webextension/background/messagePorts.js>.
+    // Clear the listeners set in <src/webextension/background/messagePorts.js>.
+    browser.runtime.onConnect.mockClearListener();
     browser.runtime.onMessage.mockClearListener();
   });
 

--- a/test/manage/actions-test.js
+++ b/test/manage/actions-test.js
@@ -1,0 +1,221 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import chai, { expect } from "chai";
+import configureStore from "redux-mock-store";
+import thunk from "redux-thunk";
+
+import { initialState } from "./mock-redux-state";
+import * as actions from "../../src/webextension/manage/actions";
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe("actions", () => {
+  let store;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+  });
+
+  afterEach(() => {
+    browser.runtime.onMessage.clearListener();
+  });
+
+  it("listItems() dispatched", async() => {
+    const items = [
+      {id: "1", title: "title 1"},
+      {id: "2", title: "title 2"},
+    ];
+    browser.runtime.onMessage.addListener((msg) => {
+      if (msg.type === "list_items") {
+        return {items};
+      }
+      return null;
+    });
+
+    await store.dispatch(actions.listItems());
+    const dispatched = store.getActions();
+    expect(dispatched).to.deep.equal([
+      { type: actions.LIST_ITEMS_STARTING,
+        actionId: dispatched[0].actionId },
+      { type: actions.LIST_ITEMS_COMPLETED,
+        actionId: dispatched[0].actionId,
+        items },
+    ]);
+  });
+
+  it("addItem() dispatched", async() => {
+    const item = {
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+    browser.runtime.onMessage.addListener((msg) => {
+      if (msg.type === "add_item") {
+        return {item: {...item, id: "1"}};
+      }
+      return null;
+    });
+
+    await store.dispatch(actions.addItem(item));
+    const dispatched = store.getActions();
+    expect(dispatched).to.deep.equal([
+      { type: actions.ADD_ITEM_STARTING,
+        actionId: dispatched[0].actionId,
+        item },
+      { type: actions.ADD_ITEM_COMPLETED,
+        actionId: dispatched[0].actionId,
+        item: {...item, id: "1"} },
+    ]);
+  });
+
+  it("updateItem() dispatched", async() => {
+    const item = {
+      id: "1",
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+    browser.runtime.onMessage.addListener((msg) => {
+      if (msg.type === "update_item") {
+        return {item};
+      }
+      return null;
+    });
+
+    await store.dispatch(actions.updateItem(item));
+    const dispatched = store.getActions();
+    expect(dispatched).to.deep.equal([
+      { type: actions.UPDATE_ITEM_STARTING,
+        actionId: dispatched[0].actionId,
+        item },
+      { type: actions.UPDATE_ITEM_COMPLETED,
+        actionId: dispatched[0].actionId,
+        item },
+    ]);
+  });
+
+  it("removeItem() dispatched", async() => {
+    const id = "1";
+    browser.runtime.onMessage.addListener((msg) => {
+      if (msg.type === "remove_item") {
+        return {};
+      }
+      return null;
+    });
+
+    await store.dispatch(actions.removeItem(id));
+    const dispatched = store.getActions();
+    expect(dispatched).to.deep.equal([
+      { type: actions.REMOVE_ITEM_STARTING,
+        actionId: dispatched[0].actionId,
+        id },
+      { type: actions.REMOVE_ITEM_COMPLETED,
+        actionId: dispatched[0].actionId,
+        id },
+    ]);
+  });
+
+  it("selectItem() dispatched", async() => {
+    const item = {
+      id: "1",
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+    browser.runtime.onMessage.addListener((msg) => {
+      if (msg.type === "get_item") {
+        return {item};
+      }
+      return null;
+    });
+
+    await store.dispatch(actions.selectItem(item.id));
+    const dispatched = store.getActions();
+    expect(dispatched).to.deep.equal([
+      { type: actions.SELECT_ITEM_STARTING,
+        actionId: dispatched[0].actionId,
+        id: item.id },
+      { type: actions.SELECT_ITEM_COMPLETED,
+        actionId: dispatched[0].actionId,
+        item },
+    ]);
+  });
+
+  it("addedItem() dispatched", () => {
+    const item = {
+      id: "1",
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+
+    store.dispatch(actions.addedItem(item));
+    expect(store.getActions()).to.deep.equal([
+      { type: actions.ADD_ITEM_COMPLETED,
+        actionId: undefined,
+        item },
+    ]);
+  });
+
+  it("updatedItem() dispatched", () => {
+    const item = {
+      id: "1",
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+
+    store.dispatch(actions.updatedItem(item));
+    expect(store.getActions()).to.deep.equal([
+      { type: actions.UPDATE_ITEM_COMPLETED,
+        actionId: undefined,
+        item },
+    ]);
+  });
+
+  it("removedItem() dispatched", () => {
+    const id = "1";
+
+    store.dispatch(actions.removedItem(id));
+    expect(store.getActions()).to.deep.equal([
+      { type: actions.REMOVE_ITEM_COMPLETED,
+        actionId: undefined,
+        id },
+    ]);
+  });
+
+
+  it("startNewItem() dispatched", () => {
+    store.dispatch(actions.startNewItem());
+    expect(store.getActions()).to.deep.equal([
+      { type: actions.START_NEW_ITEM },
+    ]);
+  });
+
+  it("cancelNewItem() dispatched", () => {
+    store.dispatch(actions.cancelNewItem());
+    expect(store.getActions()).to.deep.equal([
+      { type: actions.CANCEL_NEW_ITEM },
+    ]);
+  });
+});

--- a/test/manage/actions-test.js
+++ b/test/manage/actions-test.js
@@ -22,7 +22,7 @@ describe("actions", () => {
   });
 
   afterEach(() => {
-    browser.runtime.onMessage.clearListener();
+    browser.runtime.onMessage.mockClearListener();
   });
 
   it("listItems() dispatched", async() => {

--- a/test/manage/actions-test.js
+++ b/test/manage/actions-test.js
@@ -4,7 +4,7 @@
 
 require("babel-polyfill");
 
-import chai, { expect } from "chai";
+import { expect } from "chai";
 import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
 

--- a/test/manage/components/app-test.js
+++ b/test/manage/components/app-test.js
@@ -7,7 +7,6 @@ require("babel-polyfill");
 import chai, { expect } from "chai";
 import chaiEnzyme from "chai-enzyme";
 import React from "react";
-import ReactDOM from "react-dom";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 

--- a/test/manage/components/item-test.js
+++ b/test/manage/components/item-test.js
@@ -6,7 +6,6 @@ require("babel-polyfill");
 
 import chai, { expect } from "chai";
 import React from "react";
-import ReactDOM from "react-dom";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
 

--- a/test/manage/components/itemDetails-test.js
+++ b/test/manage/components/itemDetails-test.js
@@ -6,10 +6,8 @@ require("babel-polyfill");
 
 import chai, { expect } from "chai";
 import React from "react";
-import ReactDOM from "react-dom";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
-import PropTypes from "prop-types";
 
 chai.use(sinonChai);
 

--- a/test/manage/components/itemList-test.js
+++ b/test/manage/components/itemList-test.js
@@ -6,7 +6,6 @@ require("babel-polyfill");
 
 import chai, { expect } from "chai";
 import React from "react";
-import ReactDOM from "react-dom";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
 

--- a/test/manage/containers/addItem-test.js
+++ b/test/manage/containers/addItem-test.js
@@ -6,7 +6,6 @@ require("babel-polyfill");
 
 import { expect } from "chai";
 import React from "react";
-import ReactDOM from "react-dom";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 

--- a/test/manage/containers/addItem-test.js
+++ b/test/manage/containers/addItem-test.js
@@ -19,7 +19,7 @@ const middlewares = [];
 const mockStore = configureStore(middlewares);
 
 describe("<AddItem/>", () => {
-  it("START_NEW_ITEM dispatched", () => {
+  it("startNewItem() dispatched", () => {
     const store = mockStore(initialState);
     const wrapper = mountWithL10n(
       <Provider store={store}>

--- a/test/manage/containers/allItems-test.js
+++ b/test/manage/containers/allItems-test.js
@@ -6,7 +6,6 @@ require("babel-polyfill");
 
 import { expect } from "chai";
 import React from "react";
-import ReactDOM from "react-dom";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import thunk from "redux-thunk";

--- a/test/manage/containers/allItems-test.js
+++ b/test/manage/containers/allItems-test.js
@@ -20,6 +20,14 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe("<AllItems/>", () => {
+  beforeEach(() => {
+    browser.runtime.onMessage.addListener(() => ({}));
+  });
+
+  afterEach(() => {
+    browser.runtime.onMessage.mockClearListener();
+  });
+
   describe("empty state", () => {
     let store, wrapper;
 

--- a/test/manage/containers/allItems-test.js
+++ b/test/manage/containers/allItems-test.js
@@ -57,7 +57,7 @@ describe("<AllItems/>", () => {
       ).prop("name")).to.equal(filledState.cache.currentItem.title);
     });
 
-    it("SELECT_ITEM dispatched", () => {
+    it("selectItem() dispatched", () => {
       wrapper.find(Item).at(0).simulate("click");
       expect(store.getActions()[0].type).to.equal(SELECT_ITEM_STARTING);
     });

--- a/test/manage/containers/currentItem-test.js
+++ b/test/manage/containers/currentItem-test.js
@@ -62,7 +62,7 @@ describe("<CurrentItem/>", () => {
       expect(details.prop("fields")).to.equal(undefined);
     });
 
-    it("ADD_ITEM dispatched", () => {
+    it("addItem() dispatched", () => {
       wrapper.find('button[type="submit"]').simulate("submit");
       expect(store.getActions()[0]).to.deep.include({
         type: actions.ADD_ITEM_STARTING,
@@ -78,7 +78,7 @@ describe("<CurrentItem/>", () => {
       });
     });
 
-    it("CANCEL_NEW_ITEM dispatched", () => {
+    it("cancelNewItem() dispatched", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
       expect(store.getActions()[0]).to.deep.equal({
         type: actions.CANCEL_NEW_ITEM,
@@ -109,7 +109,7 @@ describe("<CurrentItem/>", () => {
       });
     });
 
-    it("UPDATE_ITEM dispatched", () => {
+    it("updateItem() dispatched", () => {
       wrapper.find('button[type="submit"]').simulate("submit");
       expect(store.getActions()[0]).to.deep.include({
         type: actions.UPDATE_ITEM_STARTING,
@@ -125,7 +125,7 @@ describe("<CurrentItem/>", () => {
       });
     });
 
-    it("REMOVE_ITEM dispatched", () => {
+    it("removeItem() dispatched", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
       expect(store.getActions()[0]).to.deep.include({
         type: actions.REMOVE_ITEM_STARTING,

--- a/test/manage/containers/currentItem-test.js
+++ b/test/manage/containers/currentItem-test.js
@@ -23,6 +23,14 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe("<CurrentItem/>", () => {
+  beforeEach(() => {
+    browser.runtime.onMessage.addListener(() => ({}));
+  });
+
+  afterEach(() => {
+    browser.runtime.onMessage.mockClearListener();
+  });
+
   describe("nothing selected", () => {
     let store, wrapper;
 

--- a/test/manage/containers/currentItem-test.js
+++ b/test/manage/containers/currentItem-test.js
@@ -4,9 +4,8 @@
 
 require("babel-polyfill");
 
-import chai, { expect } from "chai";
+import { expect } from "chai";
 import React from "react";
-import ReactDOM from "react-dom";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import thunk from "redux-thunk";

--- a/test/manage/messagePorts-test.js
+++ b/test/manage/messagePorts-test.js
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import { expect } from "chai";
+import configureStore from "redux-mock-store";
+import thunk from "redux-thunk";
+
+import { initialState } from "./mock-redux-state";
+import * as actions from "../../src/webextension/manage/actions";
+import initializeMessagePorts from "../../src/webextension/manage/messagePorts";
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe("message ports (manage side)", () => {
+  let messagePort, store;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+    browser.runtime.onConnect.addListener((port) => {
+      messagePort = port;
+    });
+    initializeMessagePorts(store);
+  });
+
+  afterEach(() => {
+    browser.runtime.onConnect.mockClearListener();
+  });
+
+  it('handle "added_item"', () => {
+    const item = {
+      id: "1",
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+    messagePort.postMessage({type: "added_item", item});
+
+    const dispatched = store.getActions();
+    expect(store.getActions()).to.deep.equal([{
+      type: actions.ADD_ITEM_COMPLETED,
+      actionId: dispatched[0].actionId,
+      item,
+    }]);
+  });
+
+  it('handle "updated_item"', () => {
+    const item = {
+      id: "1",
+      title: "title",
+      entry: {
+        kind: "login",
+        username: "username",
+        password: "password",
+      },
+    };
+    messagePort.postMessage({type: "updated_item", item});
+
+    const dispatched = store.getActions();
+    expect(store.getActions()).to.deep.equal([{
+      type: actions.UPDATE_ITEM_COMPLETED,
+      actionId: dispatched[0].actionId,
+      item,
+    }]);
+  });
+
+  it('handle "removed_item"', () => {
+    const id = "1";
+    messagePort.postMessage({type: "removed_item", id});
+
+    const dispatched = store.getActions();
+    expect(store.getActions()).to.deep.equal([{
+      type: actions.REMOVE_ITEM_COMPLETED,
+      actionId: dispatched[0].actionId,
+      id,
+    }]);
+  });
+
+});

--- a/test/manage/mock-redux-state.js
+++ b/test/manage/mock-redux-state.js
@@ -26,6 +26,7 @@ export const filledState = {
       id: "1",
       title: "title 1",
       entry: {
+        kind: "login",
         username: "username 1",
         password: "password 1",
       },

--- a/test/manage/reducers-test.js
+++ b/test/manage/reducers-test.js
@@ -1,0 +1,333 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import chai, { expect } from "chai";
+import React from "react";
+import ReactDOM from "react-dom";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import thunk from "redux-thunk";
+
+import { initialState } from "./mock-redux-state";
+import * as actions from "../../src/webextension/manage/actions";
+import {
+  cacheReducer, uiReducer
+} from "../../src/webextension/manage/reducers";
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe("reducers", () => {
+  describe("cache reducer", () => {
+    it("initial state", () => {
+      const action = {};
+
+      expect(cacheReducer(undefined, action)).to.deep.equal({
+        items: [],
+        currentItem: null,
+        pendingAdd: null,
+      });
+    });
+
+    it("handle LIST_ITEMS_COMPLETED", () => {
+      const action = {
+        type: actions.LIST_ITEMS_COMPLETED,
+        items: [
+          {id: "1", title: "title 1"},
+          {id: "2", title: "title 2"},
+        ],
+      };
+
+      expect(cacheReducer(undefined, action)).to.deep.equal({
+        items: action.items,
+        currentItem: null,
+        pendingAdd: null,
+      });
+    });
+
+    describe("handle ADD_ITEM_*", () => {
+      it("handle ADD_ITEM_STARTING", () => {
+        const action = {
+          type: actions.ADD_ITEM_STARTING,
+          actionId: 0,
+          item: {
+            title: "title",
+            entry: {
+              kind: "login",
+              username: "username",
+              password: "password",
+            }
+          },
+        };
+
+        expect(cacheReducer(undefined, action)).to.deep.equal({
+          items: [],
+          currentItem: null,
+          pendingAdd: action.actionId,
+        });
+      });
+
+      it("handle ADD_ITEM_COMPLETED (direct)", () => {
+        const state = {
+          items: [],
+          currentItem: null,
+          pendingAdd: 0,
+        };
+        const action = {
+          type: actions.ADD_ITEM_COMPLETED,
+          actionId: 0,
+          item: {
+            title: "title",
+            id: "1",
+            entry: {
+              kind: "login",
+              username: "username",
+              password: "password",
+            }
+          },
+        };
+
+        expect(cacheReducer(state, action)).to.deep.equal({
+          items: [{id: action.item.id, title: action.item.title}],
+          currentItem: action.item,
+          pendingAdd: null,
+        });
+      });
+
+      it("handle ADD_ITEM_COMPLETED (indirect)", () => {
+        const state = {
+          items: [],
+          currentItem: null,
+          pendingAdd: 1,
+        };
+        const action = {
+          type: actions.ADD_ITEM_COMPLETED,
+          actionId: 0,
+          item: {
+            title: "title",
+            id: "1",
+            entry: {
+              kind: "login",
+              username: "username",
+              password: "password",
+            }
+          },
+        };
+
+        expect(cacheReducer(state, action)).to.deep.equal({
+          items: [{id: action.item.id, title: action.item.title}],
+          currentItem: null,
+          pendingAdd: 1,
+        });
+      });
+    });
+
+    describe("handle UPDATE_ITEM_COMPLETED", () => {
+      it("selected", () => {
+        const state = {
+          items: [
+            {id: "1", title: "original title"},
+            {id: "2", title: "another title"},
+          ],
+          currentItem: {
+            title: "original title",
+            id: "1",
+            entry: {
+              kind: "login",
+              username: "original username",
+              password: "original password",
+            },
+          },
+          pendingAdd: null,
+        };
+        const action = {
+          type: actions.UPDATE_ITEM_COMPLETED,
+          actionId: 0,
+          item: {
+            title: "updated title",
+            id: "1",
+            entry: {
+              kind: "login",
+              username: "updated username",
+              password: "updated password",
+            },
+          },
+        };
+
+        expect(cacheReducer(state, action)).to.deep.equal({
+          items: [
+            {id: action.item.id, title: action.item.title},
+            state.items[1],
+          ],
+          currentItem: action.item,
+          pendingAdd: null,
+        });
+      });
+
+      it("unselected", () => {
+        const state = {
+          items: [
+            {id: "1", title: "original title"},
+            {id: "2", title: "another title"},
+          ],
+          currentItem: null,
+          pendingAdd: null,
+        };
+        const action = {
+          type: actions.UPDATE_ITEM_COMPLETED,
+          actionId: 0,
+          item: {
+            title: "updated title",
+            id: "1",
+            entry: {
+              kind: "login",
+              username: "updated username",
+              password: "updated password",
+            },
+          },
+        };
+
+        expect(cacheReducer(state, action)).to.deep.equal({
+          items: [
+            {id: action.item.id, title: action.item.title},
+            state.items[1],
+          ],
+          currentItem: null,
+          pendingAdd: null,
+        });
+      });
+    });
+
+    describe("handle REMOVE_ITEM_COMPLETED", () => {
+      it("selected", () => {
+        const state = {
+          items: [{id: "1", title: "title"}],
+          currentItem: {
+            title: "title",
+            id: "1",
+            entry: {
+              kind: "login",
+              username: "username",
+              password: "password",
+            },
+          },
+          pendingAdd: null,
+        };
+        const action = {
+          type: actions.REMOVE_ITEM_COMPLETED,
+          actionId: 0,
+          id: "1",
+        };
+
+        expect(cacheReducer(state, action)).to.deep.equal({
+          items: [],
+          currentItem: null,
+          pendingAdd: null,
+        });
+      });
+
+      it("unselected", () => {
+        const state = {
+          items: [
+            {id: "1", title: "title"},
+            {id: "2", title: "other title"},
+          ],
+          currentItem: {
+            title: "title",
+            id: "1",
+            entry: {
+              kind: "login",
+              username: "username",
+              password: "password",
+            },
+          },
+          pendingAdd: null,
+        };
+        const action = {
+          type: actions.REMOVE_ITEM_COMPLETED,
+          actionId: 0,
+          id: "2",
+        };
+
+        expect(cacheReducer(state, action)).to.deep.equal({
+          items: [state.items[0]],
+          currentItem: state.currentItem,
+          pendingAdd: null,
+        });
+      });
+    });
+
+    it("handle SELECT_ITEM_COMPLETED", () => {
+      const state = {
+        items: [{id: "1", title: "title"}],
+        currentItem: null,
+        pendingAdd: null,
+      };
+      const action = {
+        type: actions.SELECT_ITEM_COMPLETED,
+        item: {
+          title: "title",
+          id: "1",
+          entry: {
+            kind: "login",
+            username: "username",
+            password: "password",
+          },
+        },
+      };
+
+      expect(cacheReducer(state, action)).to.deep.equal({
+        items: state.items,
+        currentItem: action.item,
+        pendingAdd: null,
+      });
+    });
+  });
+
+  describe("ui reducer", () => {
+    it("initial state", () => {
+      expect(uiReducer(undefined, {})).to.deep.equal({
+        newItem: false,
+      });
+    });
+
+    it("handle START_NEW_ITEM", () => {
+      const action = {
+        type: actions.START_NEW_ITEM,
+      };
+
+      expect(uiReducer(undefined, action)).to.deep.equal({
+        newItem: true,
+      });
+    });
+
+    it("handle CANCEL_NEW_ITEM", () => {
+      const state = {
+        newItem: true,
+      };
+      const action = {
+        type: actions.CANCEL_NEW_ITEM,
+      };
+
+      expect(uiReducer(state, action)).to.deep.equal({
+        newItem: false,
+      });
+    });
+
+    it("handle ADD_ITEM_COMPLETED", () => {
+      const state = {
+        newItem: true,
+      };
+      const action = {
+        type: actions.ADD_ITEM_COMPLETED,
+      };
+
+      expect(uiReducer(state, action)).to.deep.equal({
+        newItem: false,
+      });
+    });
+  });
+});

--- a/test/manage/reducers-test.js
+++ b/test/manage/reducers-test.js
@@ -4,21 +4,12 @@
 
 require("babel-polyfill");
 
-import chai, { expect } from "chai";
-import React from "react";
-import ReactDOM from "react-dom";
-import configureStore from "redux-mock-store";
-import { Provider } from "react-redux";
-import thunk from "redux-thunk";
+import { expect } from "chai";
 
-import { initialState } from "./mock-redux-state";
 import * as actions from "../../src/webextension/manage/actions";
 import {
   cacheReducer, uiReducer
 } from "../../src/webextension/manage/reducers";
-
-const middlewares = [thunk];
-const mockStore = configureStore(middlewares);
 
 describe("reducers", () => {
   describe("cache reducer", () => {

--- a/test/mock-l10n.js
+++ b/test/mock-l10n.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { mount } from "enzyme";
-import PropTypes from "prop-types";
 import React from "react";
 import { MessageContext } from "fluent/compat";
 import {

--- a/test/setup.js
+++ b/test/setup.js
@@ -31,8 +31,20 @@ global.navigator = {
 
 global.browser = {
   runtime: {
-    sendMessage: async function(msg) {
-      return {};
-    }
+    onMessage: {
+      _listener: null,
+
+      addListener(fn) {
+        this._listener = fn;
+      },
+
+      clearListener() {
+        this.addListener(null);
+      },
+    },
+
+    async sendMessage(msg) {
+      return this.onMessage._listener ? this.onMessage._listener(msg) : {};
+    },
   }
 };


### PR DESCRIPTION
Note: this PR is based on #55, so ignore the first 4 commits here.

This adds tests for the Redux-only bits (actions and reducers), plus fixes lint issues in `test/`. This brings us to 67% coverage (by statement).