### PR TITLE
Add a filter to search for items

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,5 @@ module.exports = {
     "comma-dangle": ["error", "always-multiline"],
     "curly": "error",
     "no-console": "warn",
-    "no-func-assign": "off",
   },
 }

--- a/src/webextension/common.js
+++ b/src/webextension/common.js
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export function makeItemSummary(item) {
-  return {title: item.title, id: item.id};
+  return {title: item.title, id: item.id, username: item.entry.username};
 }

--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -1,4 +1,8 @@
 add-item = Add Item
+
+item-summary-no-title = (no title)
+item-summary-no-username = (no username)
+
 no-item = No item selected
 
 new-item-title = New Item

--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -17,3 +17,9 @@ save-item = Save
 cancel-item = Cancel
 update-item = Update
 delete-item = Delete
+
+// These strings are for our generic widgets. They should probably go in a
+// separate file when we have a way to do that.
+[[widgets]]
+
+filter-input-clear = Clear

--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -1,4 +1,5 @@
 add-item = Add Item
+item-filter.placeholder = Filter…
 
 item-summary-no-title = (no title)
 item-summary-no-username = (no username)

--- a/src/webextension/manage/actions.js
+++ b/src/webextension/manage/actions.js
@@ -20,6 +20,8 @@ export const SELECT_ITEM_COMPLETED = Symbol("SELECT_ITEM_COMPLETED");
 export const START_NEW_ITEM = Symbol("START_NEW_ITEM");
 export const CANCEL_NEW_ITEM = Symbol("CANCEL_NEW_ITEM");
 
+export const FILTER_ITEMS = Symbol("FILTER_ITEMS");
+
 // The action ID is used to correlate async actions with each other (i.e.
 // FOO_STARTING and FOO_COMPLETED).
 let nextActionId = 0;
@@ -187,5 +189,13 @@ export function startNewItem() {
 export function cancelNewItem() {
   return {
     type: CANCEL_NEW_ITEM,
+  };
+}
+
+
+export function filterItems(filter) {
+  return {
+    type: FILTER_ITEMS,
+    filter,
   };
 }

--- a/src/webextension/manage/components/app.js
+++ b/src/webextension/manage/components/app.js
@@ -7,6 +7,7 @@ import React from "react";
 import AddItem from "../containers/add-item";
 import AllItems from "../containers/all-items";
 import CurrentItem from "../containers/current-item";
+import ItemFilter from "../containers/item-filter";
 
 import styles from "./app.css";
 
@@ -14,6 +15,7 @@ export default function App() {
   return (
     <section className={styles.app}>
       <aside>
+        <ItemFilter/>
         <AllItems/>
         <AddItem/>
       </aside>

--- a/src/webextension/manage/components/item-list.js
+++ b/src/webextension/manage/components/item-list.js
@@ -12,7 +12,7 @@ export default function ItemList({items, selected, onItemClick}) {
   return (
     <ul className={styles.itemList}>
       {items.map((item) => (
-        <Item key={item.id} name={item.title}
+         <Item key={item.id} title={item.title} username={item.username}
                selected={item.id === selected}
                onClick={() => onItemClick(item.id)}/>
       ))}
@@ -25,6 +25,7 @@ ItemList.propTypes = {
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired,
+      username: PropTypes.string.isRequired,
     }).isRequired
   ).isRequired,
   selected: PropTypes.string,

--- a/src/webextension/manage/components/item.css
+++ b/src/webextension/manage/components/item.css
@@ -11,3 +11,8 @@
   color: HighlightText;
   background-color: Highlight;
 }
+
+.subtitle {
+  font-size: 80%;
+  opacity: 0.75;
+}

--- a/src/webextension/manage/components/item.js
+++ b/src/webextension/manage/components/item.js
@@ -2,20 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { withLocalization } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
 import styles from "./item.css";
 
-export default function Item({name, selected, onClick}) {
+function Item({title, username, selected, getString, onClick}) {
   const attrs = (selected) ? {"data-selected": true} : {};
   return (
-    <li className={styles.item} {...attrs} onClick={onClick}>{name}</li>
+    <li className={styles.item} {...attrs} onClick={onClick}>
+      <div>
+        {title || getString("item-summary-no-title")}
+      </div>
+      <div className={styles.subtitle}>
+        {username || getString("item-summary-no-username")}
+      </div>
+    </li>
   );
 }
 
 Item.propTypes = {
-  name: PropTypes.string.isRequired,
-  selected: PropTypes.bool.isRequired,
+  title: PropTypes.string,
+  username: PropTypes.string,
+  selected: PropTypes.bool,
+  getString: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
 };
+
+export default withLocalization(Item);

--- a/src/webextension/manage/containers/add-item.js
+++ b/src/webextension/manage/containers/add-item.js
@@ -24,5 +24,4 @@ AddItem.propTypes = {
   dispatch: PropTypes.func.isRequired,
 };
 
-AddItem = connect()(AddItem);
-export default AddItem;
+export default connect()(AddItem);

--- a/src/webextension/manage/containers/all-items.js
+++ b/src/webextension/manage/containers/all-items.js
@@ -5,20 +5,22 @@
 import { connect } from "react-redux";
 
 import { selectItem } from "../actions";
+import { filterItem } from "../filter.js";
 import ItemList from "../components/item-list";
 
 const collator = new Intl.Collator();
 
-const AllItems = connect(
+export default connect(
   (state) => {
     let currentId = null;
     if (!state.ui.newItem && state.cache.currentItem) {
       currentId = state.cache.currentItem.id;
     }
+
     return {
-      items: [...state.cache.items].sort(
-        (a, b) => collator.compare(a.title, b.title)
-      ),
+      items: state.cache.items
+             .filter((i) => filterItem(state.ui.filter, i))
+             .sort((a, b) => collator.compare(a.title, b.title)),
       selected: currentId,
     };
   },
@@ -26,5 +28,3 @@ const AllItems = connect(
     onItemClick: (id) => dispatch(selectItem(id)),
   })
 )(ItemList);
-
-export default AllItems;

--- a/src/webextension/manage/containers/current-item.js
+++ b/src/webextension/manage/containers/current-item.js
@@ -112,7 +112,7 @@ CurrentItem.propTypes = {
   onAction: PropTypes.func.isRequired,
 };
 
-CurrentItem = connect(
+export default connect(
   (state) => ({
     item: state.ui.newItem ? NEW_ITEM : state.cache.currentItem,
   }),
@@ -122,5 +122,3 @@ CurrentItem = connect(
     },
   })
 )(CurrentItem);
-
-export default CurrentItem;

--- a/src/webextension/manage/containers/item-filter.js
+++ b/src/webextension/manage/containers/item-filter.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Localized } from "fluent-react";
+import PropTypes from "prop-types";
+import React from "react";
+import { connect } from "react-redux";
+
+import { filterItems } from "../actions";
+import { parseFilterString } from "../filter";
+import FilterInput from "../../widgets/filter-input";
+
+function ItemFilter({dispatch}) {
+  return (
+    <Localized id="item-filter">
+      <FilterInput placeholder="fILTEr…" onChange={(value) => {
+        dispatch(filterItems(parseFilterString(value)));
+      }}/>
+    </Localized>
+  );
+}
+
+ItemFilter.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+};
+
+export default connect()(ItemFilter);

--- a/src/webextension/manage/filter.js
+++ b/src/webextension/manage/filter.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const defaultFilter = [];
+
+export function parseFilterString(filter) {
+  filter = filter.trim();
+  if (!filter) {
+    return [];
+  }
+  return filter.split(/\s+/).map((i) => i.toLocaleLowerCase());
+}
+
+export function filterItem(filter, item) {
+  for (let i of filter) {
+    if (!item.title.toLocaleLowerCase().includes(i) &&
+        !item.username.toLocaleLowerCase().includes(i)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/webextension/manage/reducers.js
+++ b/src/webextension/manage/reducers.js
@@ -7,9 +7,10 @@ import { combineReducers } from "redux";
 import {
   LIST_ITEMS_COMPLETED, ADD_ITEM_STARTING, ADD_ITEM_COMPLETED,
   UPDATE_ITEM_COMPLETED, REMOVE_ITEM_COMPLETED, SELECT_ITEM_COMPLETED,
-  START_NEW_ITEM, CANCEL_NEW_ITEM,
+  START_NEW_ITEM, CANCEL_NEW_ITEM, FILTER_ITEMS,
 } from "./actions";
 import { makeItemSummary } from "../common";
+import { defaultFilter } from "./filter";
 
 function maybeAddCurrentItem(state, action) {
   if (state.pendingAdd === action.actionId) {
@@ -76,7 +77,9 @@ export function cacheReducer(state = {
   }
 }
 
-export function uiReducer(state = {newItem: false}, action) {
+export function uiReducer(state = {
+  newItem: false, filter: defaultFilter,
+}, action) {
   switch (action.type) {
   case START_NEW_ITEM:
     return {...state, newItem: true};
@@ -84,6 +87,8 @@ export function uiReducer(state = {newItem: false}, action) {
     return {...state, newItem: false};
   case ADD_ITEM_COMPLETED:
     return {...state, newItem: false};
+  case FILTER_ITEMS:
+    return {...state, filter: action.filter};
   default:
     return state;
   }

--- a/src/webextension/widgets/filter-input.css
+++ b/src/webextension/widgets/filter-input.css
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.filter-input {
+  display: flex;
+}
+
+.filter-input > span {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.filter-input > span > input {
+  width: 100%;
+}
+
+.filter-input > button {
+  margin-inline-start: -1px;
+  margin-bottom: 0;
+}

--- a/src/webextension/widgets/filter-input.js
+++ b/src/webextension/widgets/filter-input.js
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from "prop-types";
+import React from "react";
+
+import styles from "./filter-input.css";
+
+export default class FilterInput extends React.Component {
+  static get propTypes() {
+    return {
+      onChange: PropTypes.func,
+      value: PropTypes.string,
+    };
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: props.value || "",
+    };
+  }
+
+  updateValue(value) {
+    if (value !== this.state.value) {
+      this.setState({value});
+      if (this.props.onChange) {
+        this.props.onChange(value);
+      }
+    }
+  }
+
+  render() {
+    // eslint-disable-next-line no-unused-vars
+    const {onChange, value, ...props} = this.props;
+
+    // Our input should probably be `type="search"`, but there's no browser-
+    // style for that.
+    return (
+      <div className={styles.filterInput}>
+        <span className="browser-style">
+          <input type="text" role="search" {...props} value={this.state.value}
+                 onChange={(e) => this.updateValue(e.target.value)}/>
+        </span>
+        <button type="button" className="browser-style"
+                onClick={() => this.updateValue("")}>X</button>
+      </div>
+    );
+  }
+}

--- a/src/webextension/widgets/filter-input.js
+++ b/src/webextension/widgets/filter-input.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -44,8 +45,10 @@ export default class FilterInput extends React.Component {
           <input type="text" role="search" {...props} value={this.state.value}
                  onChange={(e) => this.updateValue(e.target.value)}/>
         </span>
-        <button type="button" className="browser-style"
-                onClick={() => this.updateValue("")}>X</button>
+        <Localized id="filter-input-clear">
+          <button type="button" className="browser-style"
+                  onClick={() => this.updateValue("")}>cLEAr</button>
+        </Localized>
       </div>
     );
   }

--- a/test/background/message-ports-test.js
+++ b/test/background/message-ports-test.js
@@ -108,9 +108,11 @@ describe("message ports (background side)", () => {
       type: "list_items",
     });
 
-    expect(result).to.deep.equal({items: [
-      {id: itemId, title: "updated title"},
-    ]});
+    expect(result).to.deep.equal({items: [{
+      id: itemId,
+      title: "updated title",
+      username: "updated username",
+    }]});
   });
 
   it('handle "remove_item"', async() => {

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export function simulateTyping(wrapper, value) {
+  wrapper.get(0).value = value;
+  wrapper.at(0).simulate("change");
+}
+

--- a/test/manage/actions-test.js
+++ b/test/manage/actions-test.js
@@ -218,4 +218,12 @@ describe("actions", () => {
       { type: actions.CANCEL_NEW_ITEM },
     ]);
   });
+
+  it("filterItems() dispatched", () => {
+    store.dispatch(actions.filterItems("my filter"));
+    expect(store.getActions()).to.deep.equal([
+      { type: actions.FILTER_ITEMS,
+        filter: "my filter" },
+    ]);
+  });
 });

--- a/test/manage/components/item-list-test.js
+++ b/test/manage/components/item-list-test.js
@@ -18,9 +18,9 @@ import ItemList from "../../../src/webextension/manage/components/item-list";
 describe("<ItemList/>", () => {
   let onItemClick, wrapper;
   const items = [
-    {id: "0", title: "title 0"},
-    {id: "1", title: "title 1"},
-    {id: "2", title: "title 2"},
+    {id: "0", title: "title 0", username: "username 0"},
+    {id: "1", title: "title 1", username: "username 1"},
+    {id: "2", title: "title 2", username: "username 2"},
   ];
 
   beforeEach(() => {

--- a/test/manage/components/item-test.js
+++ b/test/manage/components/item-test.js
@@ -21,9 +21,27 @@ describe("<Item/>", () => {
     onClick = sinon.spy();
   });
 
+  it("render title and username", () => {
+    const wrapper = mountWithL10n(
+      <Item title="title" username="username" onClick={onClick}/>
+    );
+    expect(wrapper.find("div").at(0).text()).to.equal("title");
+    expect(wrapper.find("div").at(1).text()).to.equal("username");
+  });
+
+  it("render blank", () => {
+    const wrapper = mountWithL10n(
+      <Item onClick={onClick}/>
+    );
+    expect(wrapper.find("div").at(0).text()).to.equal("item-summary-no-title");
+    expect(wrapper.find("div").at(1).text()).to.equal(
+      "item-summary-no-username"
+    );
+  });
+
   it("onClick called", () => {
     const wrapper = mountWithL10n(
-      <Item name="title" selected={true} onClick={onClick}/>
+      <Item title="title" username="username" onClick={onClick}/>
     );
     wrapper.simulate("click");
     expect(onClick).to.have.been.calledWith();

--- a/test/manage/containers/all-items-test.js
+++ b/test/manage/containers/all-items-test.js
@@ -61,7 +61,7 @@ describe("<AllItems/>", () => {
       expect(wrapper.find(Item)).to.have.length(3);
       expect(wrapper.find(Item).filterWhere(
         (x) => x.prop("selected")
-      ).prop("name")).to.equal(filledState.cache.currentItem.title);
+      ).prop("title")).to.equal(filledState.cache.currentItem.title);
     });
 
     it("selectItem() dispatched", () => {

--- a/test/manage/containers/all-items-test.js
+++ b/test/manage/containers/all-items-test.js
@@ -69,4 +69,24 @@ describe("<AllItems/>", () => {
       expect(store.getActions()[0].type).to.equal(SELECT_ITEM_STARTING);
     });
   });
+
+  describe("filled state (with filters)", () => {
+    let store, wrapper;
+
+    beforeEach(() => {
+      store = mockStore({
+        ...filledState,
+        ui: {...filledState.ui, filter: ["2"]},
+      });
+      wrapper = mountWithL10n(
+        <Provider store={store}>
+          <AllItems/>
+        </Provider>
+      );
+    });
+
+    it("render items", () => {
+      expect(wrapper.find(Item)).to.have.length(1);
+    });
+  });
 });

--- a/test/manage/containers/item-filter-test.js
+++ b/test/manage/containers/item-filter-test.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import { expect } from "chai";
+import React from "react";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import thunk from "redux-thunk";
+
+import { simulateTyping } from "../../common";
+import mountWithL10n from "../../mock-l10n";
+import { initialState } from "../mock-redux-state";
+
+import ItemFilter from
+       "../../../src/webextension/manage/containers/item-filter";
+import { FILTER_ITEMS } from "../../../src/webextension/manage/actions";
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe("<ItemFilter/>", () => {
+  let store, wrapper;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+    wrapper = mountWithL10n(
+      <Provider store={store}>
+        <ItemFilter/>
+      </Provider>
+    );
+  });
+
+  it("filterItems() dispatched on text input", () => {
+    simulateTyping(wrapper.find("input"), "my filter");
+
+    expect(store.getActions()[0]).to.deep.equal({
+      type: FILTER_ITEMS,
+      filter: ["my", "filter"],
+    });
+  });
+
+  it("filterItems() dispatched on reset", () => {
+    simulateTyping(wrapper.find("input"), "my filter");
+    wrapper.find("button").simulate("click");
+
+    expect(store.getActions()[1]).to.deep.equal({
+      type: FILTER_ITEMS,
+      filter: [],
+    });
+  });
+});

--- a/test/manage/filter-test.js
+++ b/test/manage/filter-test.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import { expect } from "chai";
+
+import * as filter from "../../src/webextension/manage/filter";
+
+describe("filters", () => {
+  describe("parseFilterString()", () => {
+    it("split on whitespace", () => {
+      expect(filter.parseFilterString("foo bar")).to.deep.equal(["foo", "bar"]);
+    });
+
+    it("trim whitespace", () => {
+      expect(filter.parseFilterString(" foo ")).to.deep.equal(["foo"]);
+    });
+
+    it("convert to lower case", () => {
+      expect(filter.parseFilterString("FOO BAR")).to.deep.equal(["foo", "bar"]);
+    });
+
+    it("empty string yields 0 filter elements", () => {
+      expect(filter.parseFilterString("")).to.deep.equal([]);
+    });
+  });
+
+  describe("filterItem()", () => {
+    const items = [
+      { title: "foo title", username: "foo username" },
+      { title: "bar title", username: "bar username" },
+    ];
+
+    describe("empty filter", () => {
+      it("match anything", () => {
+        for (let i of items) {
+          expect(filter.filterItem(filter.defaultFilter, i)).to.equal(true);
+        }
+      });
+    });
+
+    describe("non-empty filter", () => {
+      let myFilter;
+
+      beforeEach(() => {
+        myFilter = filter.parseFilterString("foo TITLE UserName");
+      });
+
+      it("parsed correctly", () => {
+        expect(myFilter).to.deep.equal(["foo", "title", "username"]);
+      });
+
+      it("match first item", () => {
+        expect(filter.filterItem(myFilter, items[0])).to.equal(true);
+      });
+
+      it("fail to match second item", () => {
+        expect(filter.filterItem(myFilter, items[1])).to.equal(false);
+      });
+    });
+  });
+});

--- a/test/manage/mock-redux-state.js
+++ b/test/manage/mock-redux-state.js
@@ -12,6 +12,7 @@ export const initialState = {
   },
   ui: {
     newItem: false,
+    filter: [],
   },
 };
 
@@ -35,5 +36,6 @@ export const filledState = {
   },
   ui: {
     newItem: false,
+    filter: [],
   },
 };

--- a/test/manage/mock-redux-state.js
+++ b/test/manage/mock-redux-state.js
@@ -18,9 +18,9 @@ export const initialState = {
 export const filledState = {
   cache: {
     items: [
-      {id: "0", title: "title 0"},
-      {id: "1", title: "title 1"},
-      {id: "2", title: "title 2"},
+      {id: "0", title: "title 0", username: "username 0"},
+      {id: "1", title: "title 1", username: "username 1"},
+      {id: "2", title: "title 2", username: "username 2"},
     ],
     currentItem: {
       id: "1",

--- a/test/manage/reducers-test.js
+++ b/test/manage/reducers-test.js
@@ -298,6 +298,7 @@ describe("reducers", () => {
     it("initial state", () => {
       expect(uiReducer(undefined, {})).to.deep.equal({
         newItem: false,
+        filter: [],
       });
     });
 
@@ -308,12 +309,14 @@ describe("reducers", () => {
 
       expect(uiReducer(undefined, action)).to.deep.equal({
         newItem: true,
+        filter: [],
       });
     });
 
     it("handle CANCEL_NEW_ITEM", () => {
       const state = {
         newItem: true,
+        filter: [],
       };
       const action = {
         type: actions.CANCEL_NEW_ITEM,
@@ -321,12 +324,14 @@ describe("reducers", () => {
 
       expect(uiReducer(state, action)).to.deep.equal({
         newItem: false,
+        filter: [],
       });
     });
 
     it("handle ADD_ITEM_COMPLETED", () => {
       const state = {
         newItem: true,
+        filter: [],
       };
       const action = {
         type: actions.ADD_ITEM_COMPLETED,
@@ -334,6 +339,23 @@ describe("reducers", () => {
 
       expect(uiReducer(state, action)).to.deep.equal({
         newItem: false,
+        filter: [],
+      });
+    });
+
+    it("handle FILTER_ITEMS", () => {
+      const state = {
+        newItem: false,
+        filter: [],
+      };
+      const action = {
+        type: actions.FILTER_ITEMS,
+        filter: ["my filter"],
+      };
+
+      expect(uiReducer(state, action)).to.deep.equal({
+        newItem: false,
+        filter: ["my filter"],
       });
     });
   });

--- a/test/manage/reducers-test.js
+++ b/test/manage/reducers-test.js
@@ -82,7 +82,11 @@ describe("reducers", () => {
         };
 
         expect(cacheReducer(state, action)).to.deep.equal({
-          items: [{id: action.item.id, title: action.item.title}],
+          items: [{
+            id: action.item.id,
+            title: action.item.title,
+            username: action.item.entry.username,
+          }],
           currentItem: action.item,
           pendingAdd: null,
         });
@@ -109,7 +113,11 @@ describe("reducers", () => {
         };
 
         expect(cacheReducer(state, action)).to.deep.equal({
-          items: [{id: action.item.id, title: action.item.title}],
+          items: [{
+            id: action.item.id,
+            title: action.item.title,
+            username: action.item.entry.username,
+          }],
           currentItem: null,
           pendingAdd: 1,
         });
@@ -150,7 +158,11 @@ describe("reducers", () => {
 
         expect(cacheReducer(state, action)).to.deep.equal({
           items: [
-            {id: action.item.id, title: action.item.title},
+            {
+              id: action.item.id,
+              title: action.item.title,
+              username: action.item.entry.username,
+            },
             state.items[1],
           ],
           currentItem: action.item,
@@ -183,7 +195,11 @@ describe("reducers", () => {
 
         expect(cacheReducer(state, action)).to.deep.equal({
           items: [
-            {id: action.item.id, title: action.item.title},
+            {
+              id: action.item.id,
+              title: action.item.title,
+              username: action.item.entry.username,
+            },
             state.items[1],
           ],
           currentItem: null,

--- a/test/widgets-test.js
+++ b/test/widgets-test.js
@@ -4,11 +4,18 @@
 
 require("babel-polyfill");
 
-import { expect } from "chai";
+import chai, { expect } from "chai";
 import { mount } from "enzyme";
 import React from "react";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+chai.use(sinonChai);
+
+import { simulateTyping } from "./common";
 
 import Button from "../src/webextension/widgets/button";
+import FilterInput from "../src/webextension/widgets/filter-input";
 import Input from "../src/webextension/widgets/input";
 
 describe("widgets", () => {
@@ -24,6 +31,48 @@ describe("widgets", () => {
       const wrapper = mount(<Button className="foo">click me</Button>);
       const realButton = wrapper.find("button");
       expect(realButton.prop("className")).to.equal("browser-style foo");
+    });
+  });
+
+  describe("<FilterInput/>", () => {
+    it("render input", () => {
+      const wrapper = mount(<FilterInput value="text"/>);
+      const realInput = wrapper.find("input");
+      expect(realInput.prop("value")).to.equal("text");
+    });
+
+    it("reset button clears filter", () => {
+      const wrapper = mount(<FilterInput/>);
+      simulateTyping(wrapper.find("input"), "text");
+      wrapper.find("button").simulate("click");
+
+      const realInput = wrapper.find("input");
+      expect(realInput.prop("value")).to.equal("");
+    });
+
+    it("onChange fired on input", () => {
+      const onChange = sinon.spy();
+      const wrapper = mount(<FilterInput onChange={onChange}/>);
+      simulateTyping(wrapper.find("input"), "text");
+
+      expect(onChange).to.have.been.calledWith("text");
+    });
+
+    it("onChange fired on reset", () => {
+      const onChange = sinon.spy();
+      const wrapper = mount(<FilterInput onChange={onChange}/>);
+      simulateTyping(wrapper.find("input"), "text");
+      wrapper.find("button").simulate("click");
+
+      expect(onChange).to.have.been.calledWith("");
+    });
+
+    it("onChange not fired if no text changed", () => {
+      const onChange = sinon.spy();
+      const wrapper = mount(<FilterInput onChange={onChange}/>);
+      wrapper.find("button").simulate("click");
+
+      expect(onChange).to.have.callCount(0);
     });
   });
 

--- a/test/widgets-test.js
+++ b/test/widgets-test.js
@@ -13,6 +13,7 @@ import sinonChai from "sinon-chai";
 chai.use(sinonChai);
 
 import { simulateTyping } from "./common";
+import mountWithL10n from "./mock-l10n";
 
 import Button from "../src/webextension/widgets/button";
 import FilterInput from "../src/webextension/widgets/filter-input";
@@ -36,13 +37,13 @@ describe("widgets", () => {
 
   describe("<FilterInput/>", () => {
     it("render input", () => {
-      const wrapper = mount(<FilterInput value="text"/>);
+      const wrapper = mountWithL10n(<FilterInput value="text"/>);
       const realInput = wrapper.find("input");
       expect(realInput.prop("value")).to.equal("text");
     });
 
     it("reset button clears filter", () => {
-      const wrapper = mount(<FilterInput/>);
+      const wrapper = mountWithL10n(<FilterInput/>);
       simulateTyping(wrapper.find("input"), "text");
       wrapper.find("button").simulate("click");
 
@@ -52,7 +53,7 @@ describe("widgets", () => {
 
     it("onChange fired on input", () => {
       const onChange = sinon.spy();
-      const wrapper = mount(<FilterInput onChange={onChange}/>);
+      const wrapper = mountWithL10n(<FilterInput onChange={onChange}/>);
       simulateTyping(wrapper.find("input"), "text");
 
       expect(onChange).to.have.been.calledWith("text");
@@ -60,7 +61,7 @@ describe("widgets", () => {
 
     it("onChange fired on reset", () => {
       const onChange = sinon.spy();
-      const wrapper = mount(<FilterInput onChange={onChange}/>);
+      const wrapper = mountWithL10n(<FilterInput onChange={onChange}/>);
       simulateTyping(wrapper.find("input"), "text");
       wrapper.find("button").simulate("click");
 
@@ -69,7 +70,7 @@ describe("widgets", () => {
 
     it("onChange not fired if no text changed", () => {
       const onChange = sinon.spy();
-      const wrapper = mount(<FilterInput onChange={onChange}/>);
+      const wrapper = mountWithL10n(<FilterInput onChange={onChange}/>);
       wrapper.find("button").simulate("click");
 
       expect(onChange).to.have.callCount(0);


### PR DESCRIPTION
This PR adds usernames to the summary list on the left and a filter that searches over the item's title and username (it splits the query on spaces and case-insensitively searches for each word individually for now).

This could still use some improvements, although it might be good enough to land already. Some stuff we should resolve (eventually) though:

* It can be confusing if the currently-selected item is filtered out; not sure what the best thing to do here is. Maybe deselect it?
* Maybe use something like Redux Forms?
* The styling of the search widget could use improvement.

![lockbox-alpha](https://user-images.githubusercontent.com/49511/30759093-1c644dda-9f92-11e7-802d-3efa715d98fe.gif)

