### PR TITLE
Quick draft of codeowners for reviews

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -8,7 +8,8 @@
 /docs/    @jimporter @devinreams
 
 # include Flod for l10n string changes
-src/webextension/locales/en-US/*.ftl    @flodolo
+# @todo uncomment below after initial string freeze
+#src/webextension/locales/en-US/*.ftl    @flodolo
 
 # otherwise, everything is to be reviewed by @jimporter
 *         @jimporter

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -7,5 +7,8 @@
 # docs are shepherded by @devinreams
 /docs/    @jimporter @devinreams
 
+# include Flod for l10n string changes
+src/webextension/locales/en-US/*.ftl    @flodolo
+
 # otherwise, everything is to be reviewed by @jimporter
 *         @jimporter

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,11 @@
+# lockbox-extension code owners
+# https://help.github.com/articles/about-codeowners/
+
+# tests should also be reviewed by @m8ttyB
+/test/    @jimporter @m8ttyB
+
+# docs are shepherded by @devinreams
+/docs/    @jimporter @devinreams
+
+# otherwise, everything is to be reviewed by @jimporter
+*         @jimporter


### PR DESCRIPTION
I'm in a documentation mood.

This will automatically add the matching code owner(s) to PR reviews (later rules take precedence): https://help.github.com/articles/about-codeowners/