### PR TITLE
Remove 'npm install' from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js: stable
 
-before_script:
-  - npm install
-
 script:
   - STRICT_LINT=1 npm run test
 


### PR DESCRIPTION
Travis automatically installs dependencies. Removing the redundant `npm install` should cut the build time by a whopping 14-18 seconds.

| COMMAND | STEP | TIME
|:----|:----:|----:|
| `$ npm install` | install.npm | 53.69s
| `$ npm install` | before_script | 14.11s
