### PR TITLE
Use the "id" property from package.json in our webextension manifest

### DIFF
--- a/src/webextension/manifest.json.tpl
+++ b/src/webextension/manifest.json.tpl
@@ -7,8 +7,8 @@
 
   "applications": {
     "gecko": {
-      "id": "lockbox@mozilla.com",
-      "update_url": "https://testpilot.firefox.com/files/lockbox@mozilla.com/updates.json"
+      "id": "{{id}}",
+      "update_url": "https://testpilot.firefox.com/files/{{id}}/updates.json"
     }
   },
 


### PR DESCRIPTION
Just noticed this after #62 landed. We should use the templated add-on ID here.