### PR TITLE
Create a scrollable, keyboard-accessible list

### DIFF
--- a/src/webextension/manage/components/app.css
+++ b/src/webextension/manage/components/app.css
@@ -9,22 +9,18 @@ body {
 .app {
   display: grid;
   grid-template-columns: 1fr 5fr;
-  grid-template-rows: auto;
+  grid-template-rows: 100vh;
   grid-gap: 1em;
-  width: 100vw;
-  height: 100vh;
 }
 
 .app > aside {
   grid-column: 1;
   background-color: #f9f9fa;
-  padding: 0 
+  display: grid;
+  grid-template-rows: auto 1fr auto;
 }
 
 .app > article {
   grid-column: 2;
-}
-
-.app > article {
   margin: 1em;
 }

--- a/src/webextension/manage/components/app.css
+++ b/src/webextension/manage/components/app.css
@@ -15,6 +15,7 @@ body {
 
 .app > aside {
   grid-column: 1;
+  min-width: 0;
   background-color: #f9f9fa;
   display: grid;
   grid-template-rows: auto 1fr auto;

--- a/src/webextension/manage/components/app.js
+++ b/src/webextension/manage/components/app.js
@@ -17,7 +17,9 @@ export default function App() {
       <aside>
         <ItemFilter/>
         <AllItems/>
-        <AddItem/>
+        <div>
+          <AddItem/>
+        </div>
       </aside>
       <article>
         <CurrentItem/>

--- a/src/webextension/manage/components/item-details.js
+++ b/src/webextension/manage/components/item-details.js
@@ -13,7 +13,7 @@ import TextArea from "../../widgets/text-area";
 import styles from "./item-details.css";
 
 // Note: ItemDetails doesn't directly interact with items from the Lockbox
-// datastore. For that, please consult <../containers/currentItem.js>.
+// datastore. For that, please consult <../containers/current-item.js>.
 
 export default class ItemDetails extends React.Component {
   static get propTypes() {

--- a/src/webextension/manage/components/item-list.js
+++ b/src/webextension/manage/components/item-list.js
@@ -12,9 +12,9 @@ export default function ItemList({items, selected, onItemSelected}) {
   return (
     <ScrollingList data={items} selected={selected}
                    onItemSelected={onItemSelected}>
-      {({item, ...props}) => {
+      {({title, username}) => {
         return (
-          <ItemSummary title={item.title} username={item.username} {...props}/>
+          <ItemSummary title={title} username={username}/>
         );
       }}
     </ScrollingList>

--- a/src/webextension/manage/components/item-list.js
+++ b/src/webextension/manage/components/item-list.js
@@ -5,7 +5,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import Item from "./item";
+import ItemSummary from "./item-summary";
 import ScrollingList from "../../widgets/scrolling-list";
 
 export default function ItemList({items, selected, onItemSelected}) {
@@ -14,7 +14,7 @@ export default function ItemList({items, selected, onItemSelected}) {
                    onItemSelected={onItemSelected}>
       {({item, ...props}) => {
         return (
-          <Item title={item.title} username={item.username} {...props}/>
+          <ItemSummary title={item.title} username={item.username} {...props}/>
         );
       }}
     </ScrollingList>

--- a/src/webextension/manage/components/item-list.js
+++ b/src/webextension/manage/components/item-list.js
@@ -6,17 +6,18 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Item from "./item";
-import styles from "./item-list.css";
+import ScrollingList from "../../widgets/scrolling-list";
 
-export default function ItemList({items, selected, onItemClick}) {
+export default function ItemList({items, selected, onItemSelected}) {
   return (
-    <ul className={styles.itemList}>
-      {items.map((item) => (
-         <Item key={item.id} title={item.title} username={item.username}
-               selected={item.id === selected}
-               onClick={() => onItemClick(item.id)}/>
-      ))}
-    </ul>
+    <ScrollingList data={items} selected={selected}
+                   onItemSelected={onItemSelected}>
+      {({item, ...props}) => {
+        return (
+          <Item title={item.title} username={item.username} {...props}/>
+        );
+      }}
+    </ScrollingList>
   );
 }
 
@@ -29,5 +30,5 @@ ItemList.propTypes = {
     }).isRequired
   ).isRequired,
   selected: PropTypes.string,
-  onItemClick: PropTypes.func.isRequired,
+  onItemSelected: PropTypes.func.isRequired,
 };

--- a/src/webextension/manage/components/item-summary.css
+++ b/src/webextension/manage/components/item-summary.css
@@ -7,6 +7,12 @@
   padding: .5em;
 }
 
+.title, .subtitle {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .subtitle {
   font-size: 80%;
   opacity: 0.75;

--- a/src/webextension/manage/components/item-summary.css
+++ b/src/webextension/manage/components/item-summary.css
@@ -7,16 +7,6 @@
   padding: .5em;
 }
 
-.item-summary[data-selected] {
-  color: InactiveCaptionText;
-  background-color: InactiveCaption;
-}
-
-*:focus .item-summary[data-selected] {
-  color: HighlightText;
-  background-color: Highlight;
-}
-
 .subtitle {
   font-size: 80%;
   opacity: 0.75;

--- a/src/webextension/manage/components/item-summary.css
+++ b/src/webextension/manage/components/item-summary.css
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.item {
+.item-summary {
   border-bottom: 1px solid #d7d7db;
   padding: .5em;
 }
 
-.item[data-selected] {
+.item-summary[data-selected] {
   color: InactiveCaptionText;
   background-color: InactiveCaption;
 }
 
-*:focus .item[data-selected] {
+*:focus .item-summary[data-selected] {
   color: HighlightText;
   background-color: Highlight;
 }

--- a/src/webextension/manage/components/item-summary.js
+++ b/src/webextension/manage/components/item-summary.js
@@ -6,12 +6,12 @@ import { withLocalization } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
-import styles from "./item.css";
+import styles from "./item-summary.css";
 
-function Item({title, username, selected, getString, onClick}) {
+function ItemSummary({title, username, selected, getString, onClick}) {
   const attrs = (selected) ? {"data-selected": true} : {};
   return (
-    <li className={styles.item} {...attrs} onClick={onClick}>
+    <li className={styles.itemSummary} {...attrs} onClick={onClick}>
       <div>
         {title || getString("item-summary-no-title")}
       </div>
@@ -22,7 +22,7 @@ function Item({title, username, selected, getString, onClick}) {
   );
 }
 
-Item.propTypes = {
+ItemSummary.propTypes = {
   title: PropTypes.string,
   username: PropTypes.string,
   selected: PropTypes.bool,
@@ -30,4 +30,10 @@ Item.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
-export default withLocalization(Item);
+ItemSummary.defaultProps = {
+  title: "",
+  username: "",
+  selected: false,
+};
+
+export default withLocalization(ItemSummary);

--- a/src/webextension/manage/components/item-summary.js
+++ b/src/webextension/manage/components/item-summary.js
@@ -11,11 +11,11 @@ import styles from "./item-summary.css";
 function ItemSummary({title, username, getString}) {
   return (
     <div className={styles.itemSummary}>
-      <div>
-        {title || getString("item-summary-no-title")}
+      <div className={styles.title}>
+        {title.trim() || getString("item-summary-no-title")}
       </div>
       <div className={styles.subtitle}>
-        {username || getString("item-summary-no-username")}
+        {username.trim() || getString("item-summary-no-username")}
       </div>
     </div>
   );

--- a/src/webextension/manage/components/item-summary.js
+++ b/src/webextension/manage/components/item-summary.js
@@ -8,26 +8,23 @@ import React from "react";
 
 import styles from "./item-summary.css";
 
-function ItemSummary({title, username, selected, getString, onClick}) {
-  const attrs = (selected) ? {"data-selected": true} : {};
+function ItemSummary({title, username, getString}) {
   return (
-    <li className={styles.itemSummary} {...attrs} onClick={onClick}>
+    <div className={styles.itemSummary}>
       <div>
         {title || getString("item-summary-no-title")}
       </div>
       <div className={styles.subtitle}>
         {username || getString("item-summary-no-username")}
       </div>
-    </li>
+    </div>
   );
 }
 
 ItemSummary.propTypes = {
   title: PropTypes.string,
   username: PropTypes.string,
-  selected: PropTypes.bool,
   getString: PropTypes.func.isRequired,
-  onClick: PropTypes.func.isRequired,
 };
 
 ItemSummary.defaultProps = {

--- a/src/webextension/manage/components/item.css
+++ b/src/webextension/manage/components/item.css
@@ -8,6 +8,11 @@
 }
 
 .item[data-selected] {
+  color: InactiveCaptionText;
+  background-color: InactiveCaption;
+}
+
+*:focus .item[data-selected] {
   color: HighlightText;
   background-color: Highlight;
 }

--- a/src/webextension/manage/containers/all-items.js
+++ b/src/webextension/manage/containers/all-items.js
@@ -25,6 +25,6 @@ export default connect(
     };
   },
   (dispatch) => ({
-    onItemClick: (id) => dispatch(selectItem(id)),
+    onItemSelected: (id) => dispatch(selectItem(id)),
   })
 )(ItemList);

--- a/src/webextension/manage/containers/all-items.js
+++ b/src/webextension/manage/containers/all-items.js
@@ -13,8 +13,8 @@ const collator = new Intl.Collator();
 export default connect(
   (state) => {
     let currentId = null;
-    if (!state.ui.newItem && state.cache.currentItem) {
-      currentId = state.cache.currentItem.id;
+    if (!state.ui.newItem && state.ui.selectedItemId) {
+      currentId = state.ui.selectedItemId;
     }
 
     return {

--- a/src/webextension/manage/reducers.js
+++ b/src/webextension/manage/reducers.js
@@ -6,8 +6,8 @@ import { combineReducers } from "redux";
 
 import {
   LIST_ITEMS_COMPLETED, ADD_ITEM_STARTING, ADD_ITEM_COMPLETED,
-  UPDATE_ITEM_COMPLETED, REMOVE_ITEM_COMPLETED, SELECT_ITEM_COMPLETED,
-  START_NEW_ITEM, CANCEL_NEW_ITEM, FILTER_ITEMS,
+  UPDATE_ITEM_COMPLETED, REMOVE_ITEM_COMPLETED, SELECT_ITEM_STARTING,
+  SELECT_ITEM_COMPLETED, START_NEW_ITEM, CANCEL_NEW_ITEM, FILTER_ITEMS,
 } from "./actions";
 import { makeItemSummary } from "../common";
 import { defaultFilter } from "./filter";
@@ -78,7 +78,7 @@ export function cacheReducer(state = {
 }
 
 export function uiReducer(state = {
-  newItem: false, filter: defaultFilter,
+  newItem: false, selectedItemId: null, filter: defaultFilter,
 }, action) {
   switch (action.type) {
   case START_NEW_ITEM:
@@ -86,7 +86,9 @@ export function uiReducer(state = {
   case CANCEL_NEW_ITEM:
     return {...state, newItem: false};
   case ADD_ITEM_COMPLETED:
-    return {...state, newItem: false};
+    return {...state, newItem: false, selectedItemId: action.item.id};
+  case SELECT_ITEM_STARTING:
+    return {...state, selectedItemId: action.id};
   case FILTER_ITEMS:
     return {...state, filter: action.filter};
   default:

--- a/src/webextension/widgets/scrolling-list.css
+++ b/src/webextension/widgets/scrolling-list.css
@@ -2,8 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.item-list {
+.scrolling-list {
   margin: 0;
   padding: 0;
   list-style: none;
+  overflow-y: auto;
+}
+
+.scrolling-list:-moz-focusring {
+  outline-style: none;
 }

--- a/src/webextension/widgets/scrolling-list.css
+++ b/src/webextension/widgets/scrolling-list.css
@@ -12,3 +12,13 @@
 .scrolling-list:-moz-focusring {
   outline-style: none;
 }
+
+.scrolling-list > li[data-selected] {
+  color: InactiveCaptionText;
+  background-color: InactiveCaption;
+}
+
+.scrolling-list:focus > li[data-selected] {
+  color: HighlightText;
+  background-color: Highlight;
+}

--- a/src/webextension/widgets/scrolling-list.css
+++ b/src/webextension/widgets/scrolling-list.css
@@ -6,6 +6,7 @@
   margin: 0;
   padding: 0;
   list-style: none;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 

--- a/src/webextension/widgets/scrolling-list.js
+++ b/src/webextension/widgets/scrolling-list.js
@@ -96,7 +96,7 @@ export default class ScrollingList extends React.Component {
           onKeyDown={(e) => this.handleKeyDown(e)}>
         {data.map((item) => {
           let props = {
-            onClick: () => onItemSelected(item.id),
+            onMouseDown: () => onItemSelected(item.id),
           };
           if (item.id === selected) {
             Object.assign(props, {

--- a/src/webextension/widgets/scrolling-list.js
+++ b/src/webextension/widgets/scrolling-list.js
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from "prop-types";
+import React from "react";
+
+import styles from "./scrolling-list.css";
+
+export default class ScrollingList extends React.Component {
+  static get propTypes() {
+    return {
+      children: PropTypes.func.isRequired,
+      data: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string,
+        }).isRequired
+      ).isRequired,
+      tabIndex: PropTypes.string,
+      selected: PropTypes.string,
+      onItemSelected: PropTypes.func.isRequired,
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      tabIndex: "0",
+      selected: null,
+    };
+  }
+
+  handleKeyDown(e) {
+    if (this.props.data.length === 0) {
+      return;
+    }
+    let currentIndex, newIndex;
+
+    switch (e.key) {
+    case "ArrowDown":
+      currentIndex = this._getCurrentIndex();
+      if (currentIndex === -1) {
+        newIndex = 0;
+      } else if (currentIndex < this.props.data.length - 1) {
+        newIndex = currentIndex + 1;
+      }
+      break;
+    case "ArrowUp":
+      currentIndex = this._getCurrentIndex();
+      if (currentIndex === -1) {
+        newIndex = 0;
+      } else if (currentIndex > 0) {
+        newIndex = currentIndex - 1;
+      }
+      break;
+    default:
+      return;
+    }
+
+    if (newIndex !== undefined) {
+      this.props.onItemSelected(this.props.data[newIndex].id);
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  }
+
+  _getCurrentIndex() {
+    return this.props.data.findIndex((i) => i.id === this.props.selected);
+  }
+
+  render() {
+    const {children, data, tabIndex, selected, onItemSelected} = this.props;
+    return (
+      <ul tabIndex={tabIndex} className={styles.scrollingList}
+          onKeyDown={(e) => this.handleKeyDown(e)}>
+        {data.map((item) => children({
+          item,
+          key: item.id,
+          selected: item.id === selected,
+          onClick: () => onItemSelected(item.id),
+        }))}
+      </ul>
+    );
+  }
+}

--- a/test/manage/components/item-list-test.js
+++ b/test/manage/components/item-list-test.js
@@ -37,7 +37,7 @@ describe("<ItemList/>", () => {
   });
 
   it("correct item is selected", () => {
-    expect(wrapper.find(ItemSummary).at(0).prop("selected")).to.equal(true);
+    expect(wrapper.find("li").at(0).prop("data-selected")).to.equal(true);
   });
 
   it("onItemSelected called", () => {

--- a/test/manage/components/item-list-test.js
+++ b/test/manage/components/item-list-test.js
@@ -16,7 +16,7 @@ import Item from "../../../src/webextension/manage/components/item";
 import ItemList from "../../../src/webextension/manage/components/item-list";
 
 describe("<ItemList/>", () => {
-  let onItemClick, wrapper;
+  let onItemSelected, wrapper;
   const items = [
     {id: "0", title: "title 0", username: "username 0"},
     {id: "1", title: "title 1", username: "username 1"},
@@ -24,10 +24,10 @@ describe("<ItemList/>", () => {
   ];
 
   beforeEach(() => {
-    onItemClick = sinon.spy();
+    onItemSelected = sinon.spy();
     wrapper = mountWithL10n(
       <ItemList items={items} selected={items[0].id}
-                onItemClick={onItemClick}/>
+                onItemSelected={onItemSelected}/>
     );
   });
 
@@ -39,8 +39,8 @@ describe("<ItemList/>", () => {
     expect(wrapper.find(Item).at(0).prop("selected")).to.equal(true);
   });
 
-  it("onItemClick called", () => {
+  it("onItemSelected called", () => {
     wrapper.find(Item).at(0).simulate("click");
-    expect(onItemClick).to.have.been.calledWith(items[0].id);
+    expect(onItemSelected).to.have.been.calledWith(items[0].id);
   });
 });

--- a/test/manage/components/item-list-test.js
+++ b/test/manage/components/item-list-test.js
@@ -41,7 +41,7 @@ describe("<ItemList/>", () => {
   });
 
   it("onItemSelected called", () => {
-    wrapper.find(ItemSummary).at(0).simulate("click");
+    wrapper.find(ItemSummary).at(0).simulate("mousedown");
     expect(onItemSelected).to.have.been.calledWith(items[0].id);
   });
 });

--- a/test/manage/components/item-list-test.js
+++ b/test/manage/components/item-list-test.js
@@ -12,8 +12,9 @@ import sinonChai from "sinon-chai";
 chai.use(sinonChai);
 
 import mountWithL10n from "../../mock-l10n";
-import Item from "../../../src/webextension/manage/components/item";
 import ItemList from "../../../src/webextension/manage/components/item-list";
+import ItemSummary from
+       "../../../src/webextension/manage/components/item-summary";
 
 describe("<ItemList/>", () => {
   let onItemSelected, wrapper;
@@ -32,15 +33,15 @@ describe("<ItemList/>", () => {
   });
 
   it("render all items", () => {
-    expect(wrapper.find(Item)).to.have.length(3);
+    expect(wrapper.find(ItemSummary)).to.have.length(3);
   });
 
   it("correct item is selected", () => {
-    expect(wrapper.find(Item).at(0).prop("selected")).to.equal(true);
+    expect(wrapper.find(ItemSummary).at(0).prop("selected")).to.equal(true);
   });
 
   it("onItemSelected called", () => {
-    wrapper.find(Item).at(0).simulate("click");
+    wrapper.find(ItemSummary).at(0).simulate("click");
     expect(onItemSelected).to.have.been.calledWith(items[0].id);
   });
 });

--- a/test/manage/components/item-summary-test.js
+++ b/test/manage/components/item-summary-test.js
@@ -12,9 +12,10 @@ import sinonChai from "sinon-chai";
 chai.use(sinonChai);
 
 import mountWithL10n from "../../mock-l10n";
-import Item from "../../../src/webextension/manage/components/item";
+import ItemSummary from
+       "../../../src/webextension/manage/components/item-summary";
 
-describe("<Item/>", () => {
+describe("<ItemSummary/>", () => {
   let onClick;
 
   beforeEach(() => {
@@ -23,7 +24,7 @@ describe("<Item/>", () => {
 
   it("render title and username", () => {
     const wrapper = mountWithL10n(
-      <Item title="title" username="username" onClick={onClick}/>
+      <ItemSummary title="title" username="username" onClick={onClick}/>
     );
     expect(wrapper.find("div").at(0).text()).to.equal("title");
     expect(wrapper.find("div").at(1).text()).to.equal("username");
@@ -31,7 +32,7 @@ describe("<Item/>", () => {
 
   it("render blank", () => {
     const wrapper = mountWithL10n(
-      <Item onClick={onClick}/>
+      <ItemSummary onClick={onClick}/>
     );
     expect(wrapper.find("div").at(0).text()).to.equal("item-summary-no-title");
     expect(wrapper.find("div").at(1).text()).to.equal(
@@ -41,7 +42,7 @@ describe("<Item/>", () => {
 
   it("onClick called", () => {
     const wrapper = mountWithL10n(
-      <Item title="title" username="username" onClick={onClick}/>
+      <ItemSummary title="title" username="username" onClick={onClick}/>
     );
     wrapper.simulate("click");
     expect(onClick).to.have.been.calledWith();

--- a/test/manage/components/item-summary-test.js
+++ b/test/manage/components/item-summary-test.js
@@ -4,47 +4,31 @@
 
 require("babel-polyfill");
 
-import chai, { expect } from "chai";
+import { expect } from "chai";
 import React from "react";
-import sinon from "sinon";
-import sinonChai from "sinon-chai";
-
-chai.use(sinonChai);
 
 import mountWithL10n from "../../mock-l10n";
 import ItemSummary from
        "../../../src/webextension/manage/components/item-summary";
 
 describe("<ItemSummary/>", () => {
-  let onClick;
-
-  beforeEach(() => {
-    onClick = sinon.spy();
-  });
-
   it("render title and username", () => {
     const wrapper = mountWithL10n(
-      <ItemSummary title="title" username="username" onClick={onClick}/>
+      <ItemSummary title="title" username="username"/>
     );
-    expect(wrapper.find("div").at(0).text()).to.equal("title");
-    expect(wrapper.find("div").at(1).text()).to.equal("username");
+    expect(wrapper.find("div > div").at(0).text()).to.equal("title");
+    expect(wrapper.find("div > div").at(1).text()).to.equal("username");
   });
 
   it("render blank", () => {
     const wrapper = mountWithL10n(
-      <ItemSummary onClick={onClick}/>
+      <ItemSummary/>
     );
-    expect(wrapper.find("div").at(0).text()).to.equal("item-summary-no-title");
-    expect(wrapper.find("div").at(1).text()).to.equal(
+    expect(wrapper.find("div > div").at(0).text()).to.equal(
+      "item-summary-no-title"
+    );
+    expect(wrapper.find("div > div").at(1).text()).to.equal(
       "item-summary-no-username"
     );
-  });
-
-  it("onClick called", () => {
-    const wrapper = mountWithL10n(
-      <ItemSummary title="title" username="username" onClick={onClick}/>
-    );
-    wrapper.simulate("click");
-    expect(onClick).to.have.been.calledWith();
   });
 });

--- a/test/manage/containers/all-items-test.js
+++ b/test/manage/containers/all-items-test.js
@@ -12,7 +12,8 @@ import thunk from "redux-thunk";
 
 import { initialState, filledState } from "../mock-redux-state";
 import mountWithL10n from "../../mock-l10n";
-import Item from "../../../src/webextension/manage/components/item";
+import ItemSummary from
+       "../../../src/webextension/manage/components/item-summary";
 import AllItems from "../../../src/webextension/manage/containers/all-items";
 import { SELECT_ITEM_STARTING } from "../../../src/webextension/manage/actions";
 
@@ -41,7 +42,7 @@ describe("<AllItems/>", () => {
     });
 
     it("render items", () => {
-      expect(wrapper.find(Item)).to.have.length(0);
+      expect(wrapper.find(ItemSummary)).to.have.length(0);
     });
   });
 
@@ -58,14 +59,14 @@ describe("<AllItems/>", () => {
     });
 
     it("render items", () => {
-      expect(wrapper.find(Item)).to.have.length(3);
-      expect(wrapper.find(Item).filterWhere(
+      expect(wrapper.find(ItemSummary)).to.have.length(3);
+      expect(wrapper.find(ItemSummary).filterWhere(
         (x) => x.prop("selected")
       ).prop("title")).to.equal(filledState.cache.currentItem.title);
     });
 
     it("selectItem() dispatched", () => {
-      wrapper.find(Item).at(0).simulate("click");
+      wrapper.find(ItemSummary).at(0).simulate("click");
       expect(store.getActions()[0].type).to.equal(SELECT_ITEM_STARTING);
     });
   });
@@ -86,7 +87,7 @@ describe("<AllItems/>", () => {
     });
 
     it("render items", () => {
-      expect(wrapper.find(Item)).to.have.length(1);
+      expect(wrapper.find(ItemSummary)).to.have.length(1);
     });
   });
 });

--- a/test/manage/containers/all-items-test.js
+++ b/test/manage/containers/all-items-test.js
@@ -67,7 +67,7 @@ describe("<AllItems/>", () => {
     });
 
     it("selectItem() dispatched", () => {
-      wrapper.find(ItemSummary).at(0).simulate("click");
+      wrapper.find(ItemSummary).at(0).simulate("mousedown");
       expect(store.getActions()[0].type).to.equal(SELECT_ITEM_STARTING);
     });
   });

--- a/test/manage/containers/all-items-test.js
+++ b/test/manage/containers/all-items-test.js
@@ -59,10 +59,11 @@ describe("<AllItems/>", () => {
     });
 
     it("render items", () => {
+      const expectedTitle = filledState.cache.currentItem.title;
       expect(wrapper.find(ItemSummary)).to.have.length(3);
-      expect(wrapper.find(ItemSummary).filterWhere(
-        (x) => x.prop("selected")
-      ).prop("title")).to.equal(filledState.cache.currentItem.title);
+      expect(wrapper.find("li").filterWhere(
+        (x) => x.prop("data-selected")
+      ).find(ItemSummary).prop("title")).to.equal(expectedTitle);
     });
 
     it("selectItem() dispatched", () => {

--- a/test/manage/mock-redux-state.js
+++ b/test/manage/mock-redux-state.js
@@ -12,6 +12,7 @@ export const initialState = {
   },
   ui: {
     newItem: false,
+    selectedItemId: null,
     filter: [],
   },
 };
@@ -41,6 +42,7 @@ export const filledState = {
   },
   ui: {
     newItem: false,
+    selectedItemId: "1",
     filter: [],
   },
 };

--- a/test/manage/reducers-test.js
+++ b/test/manage/reducers-test.js
@@ -325,6 +325,7 @@ describe("reducers", () => {
     it("initial state", () => {
       expect(uiReducer(undefined, {})).to.deep.equal({
         newItem: false,
+        selectedItemId: null,
         filter: [],
       });
     });
@@ -336,6 +337,7 @@ describe("reducers", () => {
 
       expect(uiReducer(undefined, action)).to.deep.equal({
         newItem: true,
+        selectedItemId: null,
         filter: [],
       });
     });
@@ -343,6 +345,7 @@ describe("reducers", () => {
     it("handle CANCEL_NEW_ITEM", () => {
       const state = {
         newItem: true,
+        selectedItemId: null,
         filter: [],
       };
       const action = {
@@ -351,6 +354,7 @@ describe("reducers", () => {
 
       expect(uiReducer(state, action)).to.deep.equal({
         newItem: false,
+        selectedItemId: null,
         filter: [],
       });
     });
@@ -358,14 +362,37 @@ describe("reducers", () => {
     it("handle ADD_ITEM_COMPLETED", () => {
       const state = {
         newItem: true,
+        selectedItemId: null,
         filter: [],
       };
       const action = {
         type: actions.ADD_ITEM_COMPLETED,
+        item: {
+          id: "1",
+        },
       };
 
       expect(uiReducer(state, action)).to.deep.equal({
         newItem: false,
+        selectedItemId: "1",
+        filter: [],
+      });
+    });
+
+    it("handle SELECT_ITEM_STARTING", () => {
+      const state = {
+        newItem: false,
+        selectedItemId: null,
+        filter: [],
+      };
+      const action = {
+        type: actions.SELECT_ITEM_STARTING,
+        id: "1",
+      };
+
+      expect(uiReducer(state, action)).to.deep.equal({
+        newItem: false,
+        selectedItemId: "1",
         filter: [],
       });
     });

--- a/test/widgets-test.js
+++ b/test/widgets-test.js
@@ -159,7 +159,7 @@ describe("widgets", () => {
 
       describe("onItemSelected()", () => {
         it("dispatched on clicking item", () => {
-          wrapper.find("li").first().simulate("click");
+          wrapper.find("li").first().simulate("mousedown");
           expect(onItemSelected).to.have.been.calledWith("1");
         });
 

--- a/test/widgets-test.js
+++ b/test/widgets-test.js
@@ -18,6 +18,7 @@ import mountWithL10n from "./mock-l10n";
 import Button from "../src/webextension/widgets/button";
 import FilterInput from "../src/webextension/widgets/filter-input";
 import Input from "../src/webextension/widgets/input";
+import ScrollingList from "../src/webextension/widgets/scrolling-list";
 import TextArea from "../src/webextension/widgets/text-area";
 
 describe("widgets", () => {
@@ -91,6 +92,112 @@ describe("widgets", () => {
       );
       const realInput = wrapper.find("input");
       expect(realInput.prop("className")).to.match(/ foo$/);
+    });
+  });
+
+  describe("<ScrollingList/>", () => {
+    let wrapper, onItemSelected;
+
+    beforeEach(() => {
+      onItemSelected = sinon.spy();
+    });
+
+    describe("empty list", () => {
+      beforeEach(() => {
+        wrapper = mount(
+          <ScrollingList data={[]} onItemSelected={onItemSelected}>
+            {({item, ...props}) => {
+              return (
+                <li {...props}>{item.name}</li>
+              );
+            }}
+          </ScrollingList>
+        );
+      });
+
+      it("render list", () => {
+        expect(wrapper.find("ul")).to.have.length(1);
+        expect(wrapper.find("li")).to.have.length(0);
+      });
+
+      it("onItemSelected() not dispatched on arrow down", () => {
+        wrapper.simulate("keydown", {key: "ArrowDown"});
+        expect(onItemSelected).to.have.callCount(0);
+      });
+
+      it("onItemSelected() not dispatched on arrow up", () => {
+        wrapper.simulate("keydown", {key: "ArrowUp"});
+        expect(onItemSelected).to.have.callCount(0);
+      });
+    });
+
+    describe("filled list", () => {
+      const data = [
+        {id: "1", name: "item 1"},
+        {id: "2", name: "item 2"},
+        {id: "3", name: "item 3"},
+      ];
+
+      beforeEach(() => {
+        wrapper = mount(
+          <ScrollingList data={data} onItemSelected={onItemSelected}>
+            {({item, ...props}) => {
+              return (
+                <li {...props}>{item.name}</li>
+              );
+            }}
+          </ScrollingList>
+        );
+      });
+
+      it("render list", () => {
+        expect(wrapper.find("ul")).to.have.length(1);
+        expect(wrapper.find("li")).to.have.length(3);
+      });
+
+      it("onItemSelected() dispatched on clicking item", () => {
+        wrapper.find("li").first().simulate("click");
+        expect(onItemSelected).to.have.been.calledWith("1");
+      });
+
+      it("onItemSelected() dispatched on arrow down", () => {
+        wrapper.setProps({selected: "1"});
+        wrapper.simulate("keydown", {key: "ArrowDown"});
+        expect(onItemSelected).to.have.been.calledWith("2");
+      });
+
+      it("onItemSelected() dispatched on arrow up", () => {
+        wrapper.setProps({selected: "3"});
+        wrapper.simulate("keydown", {key: "ArrowUp"});
+        expect(onItemSelected).to.have.been.calledWith("2");
+      });
+
+      it("onItemSelected() dispatched on arrow down for no selection", () => {
+        wrapper.simulate("keydown", {key: "ArrowDown"});
+        expect(onItemSelected).to.have.been.calledWith("1");
+      });
+
+      it("onItemSelected() dispatched on arrow up for no selection", () => {
+        wrapper.simulate("keydown", {key: "ArrowUp"});
+        expect(onItemSelected).to.have.been.calledWith("1");
+      });
+
+      it("onItemSelected() not dispatched on arrow down for last item", () => {
+        wrapper.setProps({selected: "3"});
+        wrapper.simulate("keydown", {key: "ArrowDown"});
+        expect(onItemSelected).to.have.callCount(0);
+      });
+
+      it("onItemSelected() not dispatched on arrow up for first item", () => {
+        wrapper.setProps({selected: "1"});
+        wrapper.simulate("keydown", {key: "ArrowUp"});
+        expect(onItemSelected).to.have.callCount(0);
+      });
+
+      it("onItemSelected() not dispatched for irrelevant key press", () => {
+        wrapper.simulate("keydown", {key: "Enter"});
+        expect(onItemSelected).to.have.callCount(0);
+      });
     });
   });
 


### PR DESCRIPTION
(Note: ignore the first 4 commits since they're in other PRs.)

This adds a generic `<ScrollingList/>` widget that we can use for our left-hand pane. It also adds keyboard accessibility to the list so users *should* be able to navigate the entire UI without touching their mouse.