### PR TITLE
Add a view mode for the item details

### DIFF
--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -6,19 +6,17 @@ item-summary-no-username = (no username)
 
 no-item = No item selected
 
-new-item-title = New Item
-update-item-title = Update Item
-
 item-details-title = Title
 item-details-origin = Origin
 item-details-username = Username
 item-details-password = Password
 item-details-notes = Notes
 
-save-item = Save
-cancel-item = Cancel
-update-item = Update
-delete-item = Delete
+item-details-edit = Edit
+item-details-delete = Delete
+
+item-details-save = Save
+item-details-cancel = Cancel
 
 // These strings are for our generic widgets. They should probably go in a
 // separate file when we have a way to do that.

--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -1,6 +1,7 @@
 add-item = Add Item
 item-filter.placeholder = Filter…
 
+item-summary-new-item = (new item)
 item-summary-no-title = (no title)
 item-summary-no-username = (no username)
 

--- a/src/webextension/manage/actions.js
+++ b/src/webextension/manage/actions.js
@@ -18,7 +18,8 @@ export const SELECT_ITEM_STARTING = Symbol("SELECT_ITEM_STARTING");
 export const SELECT_ITEM_COMPLETED = Symbol("SELECT_ITEM_COMPLETED");
 
 export const START_NEW_ITEM = Symbol("START_NEW_ITEM");
-export const CANCEL_NEW_ITEM = Symbol("CANCEL_NEW_ITEM");
+export const EDIT_CURRENT_ITEM = Symbol("EDIT_CURRENT_ITEM");
+export const CANCEL_EDITING = Symbol("CANCEL_EDITING");
 
 export const FILTER_ITEMS = Symbol("FILTER_ITEMS");
 
@@ -186,9 +187,15 @@ export function startNewItem() {
   };
 }
 
-export function cancelNewItem() {
+export function editCurrentItem() {
   return {
-    type: CANCEL_NEW_ITEM,
+    type: EDIT_CURRENT_ITEM,
+  };
+}
+
+export function cancelEditing() {
+  return {
+    type: CANCEL_EDITING,
   };
 }
 

--- a/src/webextension/manage/common.js
+++ b/src/webextension/manage/common.js
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This is a string instead of a symbol since we need to be able to use it as a
+// React `key` inside a list.
+export const NEW_ITEM_ID = "new-item";

--- a/src/webextension/manage/components/edit-item-details.js
+++ b/src/webextension/manage/components/edit-item-details.js
@@ -47,6 +47,10 @@ export default class EditItemDetails extends React.Component {
     this.state = {...props.fields};
   }
 
+  componentDidMount() {
+    this._firstField.focus();
+  }
+
   componentWillReceiveProps(props) {
     this.setState({...props.fields});
   }
@@ -65,6 +69,7 @@ export default class EditItemDetails extends React.Component {
             <span>tITLe</span>
           </Localized>
           <Input type="text" name="title" value={this.state.title}
+                 ref={(element) => this._firstField = element}
                  onChange={(e) => this.setState({title: e.target.value})}/>
         </label>
         <label>

--- a/src/webextension/manage/components/edit-item-details.js
+++ b/src/webextension/manage/components/edit-item-details.js
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Localized } from "fluent-react";
+import PropTypes from "prop-types";
+import React from "react";
+
+import Button from "../../widgets/button";
+import Input from "../../widgets/input";
+import TextArea from "../../widgets/text-area";
+
+import styles from "./item-details.css";
+
+// Note: EditItemDetails doesn't directly interact with items from the Lockbox
+// datastore. For that, please consult <../containers/current-item.js>.
+
+export default class EditItemDetails extends React.Component {
+  static get propTypes() {
+    return {
+      fields: PropTypes.shape({
+        title: PropTypes.string.isRequired,
+        origin: PropTypes.string.isRequired,
+        username: PropTypes.string.isRequired,
+        password: PropTypes.string.isRequired,
+        notes: PropTypes.string.isRequired,
+      }),
+      onSave: PropTypes.func.isRequired,
+      onCancel: PropTypes.func.isRequired,
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      fields: {
+        title: "",
+        origin: "",
+        username: "",
+        password: "",
+        notes: "",
+      },
+    };
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {...props.fields};
+  }
+
+  componentWillReceiveProps(props) {
+    this.setState({...props.fields});
+  }
+
+  render() {
+    const {onSave, onCancel} = this.props;
+
+    return (
+      <form className={`${styles.itemDetails} ${styles.editing}`}
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSave(this.state);
+            }}>
+        <label>
+          <Localized id="item-details-title">
+            <span>tITLe</span>
+          </Localized>
+          <Input type="text" name="title" value={this.state.title}
+                 onChange={(e) => this.setState({title: e.target.value})}/>
+        </label>
+        <label>
+          <Localized id="item-details-origin">
+            <span>oRIGIn</span>
+          </Localized>
+          <Input type="text" name="origin" value={this.state.origin}
+                 onChange={(e) => this.setState({origin: e.target.value})}/>
+        </label>
+        <label>
+          <Localized id="item-details-username">
+            <span>uSERNAMe</span>
+          </Localized>
+          <Input type="text" name="username" value={this.state.username}
+                 onChange={(e) => this.setState({username: e.target.value})}/>
+        </label>
+        <label>
+          <Localized id="item-details-password">
+            <span>pASSWORd</span>
+          </Localized>
+          <Input type="text" name="password" value={this.state.password}
+                 onChange={(e) => this.setState({password: e.target.value})}/>
+        </label>
+        <label>
+          <Localized id="item-details-notes">
+            <span>nOTEs</span>
+          </Localized>
+          <TextArea name="notes" value={this.state.notes}
+                    onChange={(e) => this.setState({notes: e.target.value})}/>
+        </label>
+        <div className={styles.buttons}>
+          <Localized id="item-details-save">
+            <Button type="submit">sAVe</Button>
+          </Localized>
+          <Localized id="item-details-cancel">
+            <Button type="button" onClick={(e) => onCancel()}>
+              cANCEl
+            </Button>
+          </Localized>
+        </div>
+      </form>
+    );
+  }
+}

--- a/src/webextension/manage/components/item-details.css
+++ b/src/webextension/manage/components/item-details.css
@@ -8,19 +8,30 @@
   grid-column-gap: 1em;
 }
 
-.item-details > label {
+.item-details > label,
+.item-details > .field {
   display: contents;
 }
 
-.item-details > label > span:first-child {
+.item-details > .buttons {
+  grid-column: 2;
+}
+
+.item-details.editing > label > span:first-child {
   /* This lines up our labels with the text in <input> elements. */
   margin-top: 3.5px;
 }
 
-.item-details > p > button + button {
-  margin-inline-start: 1ch;
+.item-details:not(.editing) > .field > span {
+  margin-top: 3.5px;
+  margin-bottom: 6px;
 }
 
 .item-details textarea {
   resize: none;
 }
+
+.buttons > button + button {
+  margin-inline-start: 1ch;
+}
+

--- a/src/webextension/manage/components/item-details.js
+++ b/src/webextension/manage/components/item-details.js
@@ -7,107 +7,59 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import Button from "../../widgets/button";
-import Input from "../../widgets/input";
-import TextArea from "../../widgets/text-area";
 
 import styles from "./item-details.css";
 
 // Note: ItemDetails doesn't directly interact with items from the Lockbox
 // datastore. For that, please consult <../containers/current-item.js>.
 
-export default class ItemDetails extends React.Component {
-  static get propTypes() {
-    return {
-      fields: PropTypes.shape({
-        title: PropTypes.string.isRequired,
-        origin: PropTypes.string.isRequired,
-        username: PropTypes.string.isRequired,
-        password: PropTypes.string.isRequired,
-        notes: PropTypes.string.isRequired,
-      }),
-      saveLabel: PropTypes.string.isRequired,
-      deleteLabel: PropTypes.string.isRequired,
-      onSave: PropTypes.func.isRequired,
-      onDelete: PropTypes.func.isRequired,
-    };
-  }
-
-  static get defaultProps() {
-    return {
-      fields: {
-        title: "",
-        origin: "",
-        username: "",
-        password: "",
-        notes: "",
-      },
-    };
-  }
-
-  constructor(props) {
-    super(props);
-    this.state = {...props.fields};
-  }
-
-  componentWillReceiveProps(props) {
-    this.setState({...props.fields});
-  }
-
-  render() {
-    const {saveLabel, deleteLabel, onSave, onDelete} = this.props;
-
-    return (
-      <form className={styles.itemDetails} onSubmit={(e) => {
-        e.preventDefault();
-        onSave(this.state);
-      }}>
-        <label>
-          <Localized id="item-details-title">
-            <span>tITLe</span>
-          </Localized>
-          <Input type="text" name="title" value={this.state.title}
-                 onChange={(e) => this.setState({title: e.target.value})}/>
-        </label>
-        <label>
-          <Localized id="item-details-origin">
-            <span>oRIGIn</span>
-          </Localized>
-          <Input type="text" name="origin" value={this.state.origin}
-                 onChange={(e) => this.setState({origin: e.target.value})}/>
-        </label>
-        <label>
-          <Localized id="item-details-username">
-            <span>uSERNAMe</span>
-          </Localized>
-          <Input type="text" name="username" value={this.state.username}
-                 onChange={(e) => this.setState({username: e.target.value})}/>
-        </label>
-        <label>
-          <Localized id="item-details-password">
-            <span>pASSWORd</span>
-          </Localized>
-          <Input type="text" name="password" value={this.state.password}
-                 onChange={(e) => this.setState({password: e.target.value})}/>
-        </label>
-        <label>
-          <Localized id="item-details-notes">
-            <span>nOTEs</span>
-          </Localized>
-          <TextArea name="notes" value={this.state.notes}
-                    onChange={(e) => this.setState({notes: e.target.value})}/>
-        </label>
-        <p></p>
-        <p>
-          <Localized id={saveLabel}>
-            <Button type="submit">sAVe</Button>
-          </Localized>
-          <Localized id={deleteLabel}>
-            <Button type="button" onClick={(e) => onDelete(this.state.id)}>
-              dELETe
-            </Button>
-          </Localized>
-        </p>
-      </form>
-    );
-  }
+export default function ItemDetails({fields, onEdit, onDelete}) {
+  return (
+    <div className={styles.itemDetails}>
+      <div className={styles.field}>
+        <Localized id="item-details-title">
+          <span>tITLe</span>
+        </Localized>
+        <span>{fields.title}</span>
+      </div>
+      <div className={styles.field}>
+        <Localized id="item-details-origin">
+          <span>oRIGIn</span>
+        </Localized>
+        <span>{fields.origin}</span>
+      </div>
+      <div className={styles.field}>
+        <Localized id="item-details-username">
+          <span>uSERNAMe</span>
+        </Localized>
+        <span>{fields.username}</span>
+      </div>
+      <div className={styles.field}>
+        <Localized id="item-details-notes">
+          <span>nOTEs</span>
+        </Localized>
+        <span>{fields.notes}</span>
+      </div>
+      <div className={styles.buttons}>
+        <Localized id="item-details-edit">
+          <Button onClick={onEdit}>eDIt</Button>
+        </Localized>
+        <Localized id="item-details-delete">
+          <Button onClick={onDelete}>dELETe</Button>
+        </Localized>
+      </div>
+    </div>
+  );
 }
+
+ItemDetails.propTypes = {
+  fields: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    origin: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    password: PropTypes.string.isRequired,
+    notes: PropTypes.string.isRequired,
+  }).isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};

--- a/src/webextension/manage/containers/all-items.js
+++ b/src/webextension/manage/containers/all-items.js
@@ -2,29 +2,44 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { withLocalization } from "fluent-react";
+import React from "react";
 import { connect } from "react-redux";
 
 import { selectItem } from "../actions";
-import { filterItem } from "../filter.js";
+import { filterItem } from "../filter";
+import { NEW_ITEM_ID } from "../common";
 import ItemList from "../components/item-list";
 
 const collator = new Intl.Collator();
 
-export default connect(
-  (state) => {
-    let currentId = null;
-    if (!state.ui.newItem && state.ui.selectedItemId) {
-      currentId = state.ui.selectedItemId;
-    }
+function AllItems({items, selected, getString, ...props}) {
+  if (selected === NEW_ITEM_ID) {
+    items = [
+      { title: getString("item-summary-new-item"),
+        id: NEW_ITEM_ID,
+        username: "" },
+      ...items,
+    ];
+  }
 
+  return <ItemList {...{items, selected, ...props}}/>;
+}
+
+AllItems.propTypes = {
+  ...ItemList.propTypes,
+};
+
+export default connect(
+  (state, ownProps) => {
     return {
       items: state.cache.items
-             .filter((i) => filterItem(state.ui.filter, i))
-             .sort((a, b) => collator.compare(a.title, b.title)),
-      selected: currentId,
+                  .filter((i) => filterItem(state.ui.filter, i))
+                  .sort((a, b) => collator.compare(a.title, b.title)),
+      selected: state.ui.selectedItemId,
     };
   },
   (dispatch) => ({
     onItemSelected: (id) => dispatch(selectItem(id)),
-  })
-)(ItemList);
+  }),
+)(withLocalization(AllItems));

--- a/src/webextension/manage/containers/current-item.js
+++ b/src/webextension/manage/containers/current-item.js
@@ -102,6 +102,6 @@ CurrentItem.propTypes = {
 export default connect(
   (state) => ({
     editing: state.ui.editing,
-    item: state.ui.newItem ? null : state.cache.currentItem,
+    item: state.cache.currentItem,
   })
 )(CurrentItem);

--- a/src/webextension/manage/reducers.js
+++ b/src/webextension/manage/reducers.js
@@ -11,6 +11,7 @@ import {
   FILTER_ITEMS,
 } from "./actions";
 import { makeItemSummary } from "../common";
+import { NEW_ITEM_ID } from "./common";
 import { defaultFilter } from "./filter";
 
 function maybeAddCurrentItem(state, action) {
@@ -73,29 +74,32 @@ export function cacheReducer(state = {
     };
   case SELECT_ITEM_COMPLETED:
     return {...state, currentItem: action.item};
+  case START_NEW_ITEM:
+    return {...state, currentItem: null};
   default:
     return state;
   }
 }
 
 export function uiReducer(state = {
-  editing: false, newItem: false, selectedItemId: null, filter: defaultFilter,
+  editing: false, selectedItemId: null, filter: defaultFilter,
 }, action) {
   switch (action.type) {
-  case START_NEW_ITEM:
-    return {...state, editing: true, newItem: true};
-  case EDIT_CURRENT_ITEM:
-    return {...state, editing: true};
-  case CANCEL_EDITING:
-    return {...state, editing: false, newItem: false};
   case ADD_ITEM_COMPLETED:
-    return {...state, editing: false, newItem: false,
-            selectedItemId: action.item.id};
+    return {...state, editing: false, selectedItemId: action.item.id};
   case UPDATE_ITEM_COMPLETED:
     return {...state, editing: false};
   case SELECT_ITEM_STARTING:
-    return {...state, editing: false, newItem: false,
-            selectedItemId: action.id};
+    return {...state, editing: false, selectedItemId: action.id};
+  case START_NEW_ITEM:
+    return {...state, editing: true, selectedItemId: NEW_ITEM_ID};
+  case EDIT_CURRENT_ITEM:
+    return {...state, editing: true};
+  case CANCEL_EDITING:
+    if (state.selectedItemId === NEW_ITEM_ID) {
+      return {...state, editing: false, selectedItemId: null};
+    }
+    return {...state, editing: false};
   case FILTER_ITEMS:
     return {...state, filter: action.filter};
   default:

--- a/src/webextension/manage/reducers.js
+++ b/src/webextension/manage/reducers.js
@@ -7,7 +7,8 @@ import { combineReducers } from "redux";
 import {
   LIST_ITEMS_COMPLETED, ADD_ITEM_STARTING, ADD_ITEM_COMPLETED,
   UPDATE_ITEM_COMPLETED, REMOVE_ITEM_COMPLETED, SELECT_ITEM_STARTING,
-  SELECT_ITEM_COMPLETED, START_NEW_ITEM, CANCEL_NEW_ITEM, FILTER_ITEMS,
+  SELECT_ITEM_COMPLETED, START_NEW_ITEM, EDIT_CURRENT_ITEM, CANCEL_EDITING,
+  FILTER_ITEMS,
 } from "./actions";
 import { makeItemSummary } from "../common";
 import { defaultFilter } from "./filter";
@@ -78,17 +79,23 @@ export function cacheReducer(state = {
 }
 
 export function uiReducer(state = {
-  newItem: false, selectedItemId: null, filter: defaultFilter,
+  editing: false, newItem: false, selectedItemId: null, filter: defaultFilter,
 }, action) {
   switch (action.type) {
   case START_NEW_ITEM:
-    return {...state, newItem: true};
-  case CANCEL_NEW_ITEM:
-    return {...state, newItem: false};
+    return {...state, editing: true, newItem: true};
+  case EDIT_CURRENT_ITEM:
+    return {...state, editing: true};
+  case CANCEL_EDITING:
+    return {...state, editing: false, newItem: false};
   case ADD_ITEM_COMPLETED:
-    return {...state, newItem: false, selectedItemId: action.item.id};
+    return {...state, editing: false, newItem: false,
+            selectedItemId: action.item.id};
+  case UPDATE_ITEM_COMPLETED:
+    return {...state, editing: false};
   case SELECT_ITEM_STARTING:
-    return {...state, selectedItemId: action.id};
+    return {...state, editing: false, newItem: false,
+            selectedItemId: action.id};
   case FILTER_ITEMS:
     return {...state, filter: action.filter};
   default:

--- a/src/webextension/widgets/input.js
+++ b/src/webextension/widgets/input.js
@@ -7,15 +7,25 @@ import React from "react";
 
 import styles from "./input.css";
 
-export default function Input({className, ...props}) {
-  let finalClassName = `${styles.input} ${className || ""}`.trimRight();
-  return (
-    <span className="browser-style">
-      <input className={finalClassName} {...props}/>
-    </span>
-  );
-}
+export default class Input extends React.Component {
+  static get propTypes() {
+    return {
+      className: PropTypes.string,
+    };
+  }
 
-Input.propTypes = {
-  className: PropTypes.string,
-};
+  focus() {
+    this.inputElement.focus();
+  }
+
+  render() {
+    const {className, ...props} = this.props;
+    const finalClassName = `${styles.input} ${className || ""}`.trimRight();
+    return (
+      <span className="browser-style">
+        <input className={finalClassName} {...props}
+               ref={(element) => this.inputElement = element}/>
+      </span>
+    );
+  }
+}

--- a/test/manage/actions-test.js
+++ b/test/manage/actions-test.js
@@ -204,7 +204,6 @@ describe("actions", () => {
     ]);
   });
 
-
   it("startNewItem() dispatched", () => {
     store.dispatch(actions.startNewItem());
     expect(store.getActions()).to.deep.equal([
@@ -212,10 +211,17 @@ describe("actions", () => {
     ]);
   });
 
-  it("cancelNewItem() dispatched", () => {
-    store.dispatch(actions.cancelNewItem());
+  it("editCurrentItem() dispatched", () => {
+    store.dispatch(actions.editCurrentItem());
     expect(store.getActions()).to.deep.equal([
-      { type: actions.CANCEL_NEW_ITEM },
+      { type: actions.EDIT_CURRENT_ITEM },
+    ]);
+  });
+
+  it("cancelEditing() dispatched", () => {
+    store.dispatch(actions.cancelEditing());
+    expect(store.getActions()).to.deep.equal([
+      { type: actions.CANCEL_EDITING },
     ]);
   });
 

--- a/test/manage/components/edit-item-details-test.js
+++ b/test/manage/components/edit-item-details-test.js
@@ -12,15 +12,15 @@ import sinonChai from "sinon-chai";
 chai.use(sinonChai);
 
 import mountWithL10n from "../../mock-l10n";
-import ItemDetails from
-       "../../../src/webextension/manage/components/item-details";
+import EditItemDetails from
+       "../../../src/webextension/manage/components/edit-item-details";
 
 function simulateTyping(wrapper, value) {
   wrapper.get(0).value = value;
   wrapper.at(0).simulate("change");
 }
 
-describe("<ItemDetails/>", () => {
+describe("<EditItemDetails/>", () => {
   const blankFields = {
     title: "",
     origin: "",
@@ -45,15 +45,17 @@ describe("<ItemDetails/>", () => {
     notes: "new notes",
   };
 
-  let onSave, onDelete, wrapper;
+  let onSave, onCancel, wrapper;
+
+  beforeEach(() => {
+    onSave = sinon.spy();
+    onCancel = sinon.spy();
+  });
 
   describe("new item", () => {
     beforeEach(() => {
-      onSave = sinon.spy();
-      onDelete = sinon.spy();
       wrapper = mountWithL10n(
-        <ItemDetails saveLabel="save-item" deleteLabel="delete-item"
-                     onSave={onSave} onDelete={onDelete}/>
+        <EditItemDetails onSave={onSave} onCancel={onCancel}/>
       );
     });
 
@@ -78,20 +80,17 @@ describe("<ItemDetails/>", () => {
       expect(onSave).to.have.been.calledWith(updatedFields);
     });
 
-    it("onDelete called", () => {
+    it("onCancel called", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
-      expect(onDelete).to.have.been.calledWith();
+      expect(onCancel).to.have.been.calledWith();
     });
   });
 
   describe("existing item", () => {
     beforeEach(() => {
-      onSave = sinon.spy();
-      onDelete = sinon.spy();
       wrapper = mountWithL10n(
-        <ItemDetails fields={originalFields}
-                     saveLabel="save-item" deleteLabel="delete-item"
-                     onSave={onSave} onDelete={onDelete}/>
+        <EditItemDetails fields={originalFields}
+                         onSave={onSave} onCancel={onCancel}/>
       );
     });
 
@@ -116,20 +115,17 @@ describe("<ItemDetails/>", () => {
       expect(onSave).to.have.been.calledWith(updatedFields);
     });
 
-    it("onDelete called", () => {
+    it("onCancel called", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
-      expect(onDelete).to.have.been.calledWith();
+      expect(onCancel).to.have.been.calledWith();
     });
   });
 
   describe("change selected item", () => {
     beforeEach(() => {
-      onSave = sinon.spy();
-      onDelete = sinon.spy();
       wrapper = mountWithL10n(
-        <ItemDetails fields={originalFields}
-                     saveLabel="save-item" deleteLabel="delete-item"
-                     onSave={onSave} onDelete={onDelete}/>
+        <EditItemDetails fields={originalFields}
+                         onSave={onSave} onCancel={onCancel}/>
       );
     });
 

--- a/test/manage/containers/all-items-test.js
+++ b/test/manage/containers/all-items-test.js
@@ -12,10 +12,12 @@ import thunk from "redux-thunk";
 
 import { initialState, filledState } from "../mock-redux-state";
 import mountWithL10n from "../../mock-l10n";
+
 import ItemSummary from
        "../../../src/webextension/manage/components/item-summary";
 import AllItems from "../../../src/webextension/manage/containers/all-items";
 import { SELECT_ITEM_STARTING } from "../../../src/webextension/manage/actions";
+import { NEW_ITEM_ID } from "../../../src/webextension/manage/common";
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -89,6 +91,31 @@ describe("<AllItems/>", () => {
 
     it("render items", () => {
       expect(wrapper.find(ItemSummary)).to.have.length(1);
+    });
+  });
+
+  describe("new item placeholder", () => {
+    let store, wrapper;
+
+    beforeEach(() => {
+      store = mockStore({
+        ...initialState,
+        ui: {
+          ...initialState.ui,
+          selectedItemId: NEW_ITEM_ID,
+        },
+      });
+      wrapper = mountWithL10n(
+        <Provider store={store}>
+          <AllItems/>
+        </Provider>
+      );
+    });
+
+    it("render items", () => {
+      const item = wrapper.find(ItemSummary);
+      expect(item).to.have.length(1);
+      expect(item.prop("title")).to.equal("item-summary-new-item");
     });
   });
 });

--- a/test/manage/containers/current-item-test.js
+++ b/test/manage/containers/current-item-test.js
@@ -12,6 +12,7 @@ import thunk from "redux-thunk";
 
 import { initialState, filledState } from "../mock-redux-state";
 import mountWithL10n from "../../mock-l10n";
+import { NEW_ITEM_ID } from "../../../src/webextension/manage/common";
 import EditItemDetails from
        "../../../src/webextension/manage/components/edit-item-details";
 import ItemDetails from
@@ -87,9 +88,19 @@ describe("<CurrentItem/>", () => {
     let store, wrapper;
 
     beforeEach(() => {
-      store = mockStore({...filledState, ui: {
-        ...filledState.ui, editing: true, newItem: true,
-      }});
+      const state = {
+        ...filledState,
+        cache: {
+          ...filledState.cache,
+          currentItem: null,
+        },
+        ui: {
+          ...filledState.ui,
+          editing: true,
+          selectedItemId: NEW_ITEM_ID,
+        },
+      };
+      store = mockStore(state);
       wrapper = mountWithL10n(
         <Provider store={store}>
           <CurrentItem/>

--- a/test/manage/containers/current-item-test.js
+++ b/test/manage/containers/current-item-test.js
@@ -12,6 +12,8 @@ import thunk from "redux-thunk";
 
 import { initialState, filledState } from "../mock-redux-state";
 import mountWithL10n from "../../mock-l10n";
+import EditItemDetails from
+       "../../../src/webextension/manage/components/edit-item-details";
 import ItemDetails from
        "../../../src/webextension/manage/components/item-details";
 import CurrentItem from
@@ -48,14 +50,11 @@ describe("<CurrentItem/>", () => {
     });
   });
 
-
-  describe("new item", () => {
+  describe("item selected", () => {
     let store, wrapper;
 
     beforeEach(() => {
-      store = mockStore({...filledState, ui: {
-        ...filledState.ui, newItem: true,
-      }});
+      store = mockStore(filledState);
       wrapper = mountWithL10n(
         <Provider store={store}>
           <CurrentItem/>
@@ -65,6 +64,41 @@ describe("<CurrentItem/>", () => {
 
     it("render item", () => {
       const details = wrapper.find(ItemDetails);
+      expect(details).to.have.length(1);
+    });
+
+    it("editCurrentItem() dispatched", () => {
+      wrapper.find("button").at(0).simulate("click");
+      expect(store.getActions()[0]).to.deep.equal({
+        type: actions.EDIT_CURRENT_ITEM,
+      });
+    });
+
+    it("removeItem() dispatched", () => {
+      wrapper.find("button").at(1).simulate("click");
+      expect(store.getActions()[0]).to.deep.include({
+        type: actions.REMOVE_ITEM_STARTING,
+        id: "1",
+      });
+    });
+  });
+
+  describe("edit new item", () => {
+    let store, wrapper;
+
+    beforeEach(() => {
+      store = mockStore({...filledState, ui: {
+        ...filledState.ui, editing: true, newItem: true,
+      }});
+      wrapper = mountWithL10n(
+        <Provider store={store}>
+          <CurrentItem/>
+        </Provider>
+      );
+    });
+
+    it("render item", () => {
+      const details = wrapper.find(EditItemDetails);
       expect(details).to.have.length(1);
       expect(details.prop("fields")).to.deep.equal({
         title: "",
@@ -93,19 +127,21 @@ describe("<CurrentItem/>", () => {
       });
     });
 
-    it("cancelNewItem() dispatched", () => {
+    it("cancelEditing() dispatched", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
       expect(store.getActions()[0]).to.deep.equal({
-        type: actions.CANCEL_NEW_ITEM,
+        type: actions.CANCEL_EDITING,
       });
     });
   });
 
-  describe("item selected", () => {
+  describe("edit existing item", () => {
     let store, wrapper;
 
     beforeEach(() => {
-      store = mockStore(filledState);
+      store = mockStore({...filledState, ui: {
+        ...filledState.ui, editing: true,
+      }});
       wrapper = mountWithL10n(
         <Provider store={store}>
           <CurrentItem/>
@@ -114,7 +150,7 @@ describe("<CurrentItem/>", () => {
     });
 
     it("render item", () => {
-      const details = wrapper.find(ItemDetails);
+      const details = wrapper.find(EditItemDetails);
       const currentItem = filledState.cache.currentItem;
       expect(details).to.have.length(1);
       expect(details.prop("fields")).to.deep.equal({
@@ -144,16 +180,15 @@ describe("<CurrentItem/>", () => {
       });
     });
 
-    it("removeItem() dispatched", () => {
+    it("cancelEditing() dispatched", () => {
       wrapper.find("button").not('[type="submit"]').simulate("click");
       expect(store.getActions()[0]).to.deep.include({
-        type: actions.REMOVE_ITEM_STARTING,
-        id: "1",
+        type: actions.CANCEL_EDITING,
       });
     });
   });
 
-  describe("item selected (no origin)", () => {
+  describe("edit existing item (no origin)", () => {
     let store, wrapper;
     let state = {
       ...filledState,
@@ -163,6 +198,10 @@ describe("<CurrentItem/>", () => {
           ...filledState.cache.currentItem,
           origins: [],
         },
+      },
+      ui: {
+        ...filledState.ui,
+        editing: true,
       },
     };
 
@@ -176,7 +215,7 @@ describe("<CurrentItem/>", () => {
     });
 
     it("render item", () => {
-      const details = wrapper.find(ItemDetails);
+      const details = wrapper.find(EditItemDetails);
       const currentItem = state.cache.currentItem;
       expect(details).to.have.length(1);
       expect(details.prop("fields")).to.deep.equal({

--- a/test/manage/containers/current-item-test.js
+++ b/test/manage/containers/current-item-test.js
@@ -109,6 +109,13 @@ describe("<CurrentItem/>", () => {
       });
     });
 
+    it("first field focused", () => {
+      const firstField = wrapper.find("input").at(0);
+      expect(firstField.matchesElement(document.activeElement)).to.equal(
+        true, "the element was not focused"
+      );
+    });
+
     it("addItem() dispatched", () => {
       wrapper.find('button[type="submit"]').simulate("submit");
       expect(store.getActions()[0]).to.deep.include({
@@ -160,6 +167,13 @@ describe("<CurrentItem/>", () => {
         password: currentItem.entry.password,
         notes: currentItem.entry.notes,
       });
+    });
+
+    it("first field focused", () => {
+      const firstField = wrapper.find("input").at(0);
+      expect(firstField.matchesElement(document.activeElement)).to.equal(
+        true, "the element was not focused"
+      );
     });
 
     it("updateItem() dispatched", () => {

--- a/test/manage/mock-redux-state.js
+++ b/test/manage/mock-redux-state.js
@@ -11,6 +11,7 @@ export const initialState = {
     pendingAdd: null,
   },
   ui: {
+    editing: false,
     newItem: false,
     selectedItemId: null,
     filter: [],
@@ -41,6 +42,7 @@ export const filledState = {
     pendingAdd: null,
   },
   ui: {
+    editing: false,
     newItem: false,
     selectedItemId: "1",
     filter: [],

--- a/test/manage/mock-redux-state.js
+++ b/test/manage/mock-redux-state.js
@@ -12,7 +12,6 @@ export const initialState = {
   },
   ui: {
     editing: false,
-    newItem: false,
     selectedItemId: null,
     filter: [],
   },
@@ -43,7 +42,6 @@ export const filledState = {
   },
   ui: {
     editing: false,
-    newItem: false,
     selectedItemId: "1",
     filter: [],
   },

--- a/test/manage/reducers-test.js
+++ b/test/manage/reducers-test.js
@@ -10,6 +10,7 @@ import * as actions from "../../src/webextension/manage/actions";
 import {
   cacheReducer, uiReducer,
 } from "../../src/webextension/manage/reducers";
+import { NEW_ITEM_ID } from "../../src/webextension/manage/common";
 
 describe("reducers", () => {
   describe("cache reducer", () => {
@@ -319,58 +320,42 @@ describe("reducers", () => {
         pendingAdd: null,
       });
     });
+
+    it("handle START_NEW_ITEM", () => {
+      const state = {
+        items: [
+          {id: "1", title: "title", username: "username",
+           origins: ["origin.com"]},
+        ],
+        currentItem: {
+          title: "title",
+          id: "1",
+          origins: ["origin.com"],
+          entry: {
+            kind: "login",
+            username: "username",
+            password: "password",
+            notes: "notes",
+          },
+        },
+        pendingAdd: null,
+      };
+      const action = {
+        type: actions.START_NEW_ITEM,
+      };
+
+      expect(cacheReducer(state, action)).to.deep.equal({
+        items: state.items,
+        currentItem: null,
+        pendingAdd: null,
+      });
+    });
   });
 
   describe("ui reducer", () => {
     it("initial state", () => {
       expect(uiReducer(undefined, {})).to.deep.equal({
         editing: false,
-        newItem: false,
-        selectedItemId: null,
-        filter: [],
-      });
-    });
-
-    it("handle START_NEW_ITEM", () => {
-      const action = {
-        type: actions.START_NEW_ITEM,
-      };
-
-      expect(uiReducer(undefined, action)).to.deep.equal({
-        editing: true,
-        newItem: true,
-        selectedItemId: null,
-        filter: [],
-      });
-    });
-
-    it("handle EDIT_CURRENT_ITEM", () => {
-      const action = {
-        type: actions.EDIT_CURRENT_ITEM,
-      };
-
-      expect(uiReducer(undefined, action)).to.deep.equal({
-        editing: true,
-        newItem: false,
-        selectedItemId: null,
-        filter: [],
-      });
-    });
-
-    it("handle CANCEL_EDITING", () => {
-      const state = {
-        editing: true,
-        newItem: true,
-        selectedItemId: null,
-        filter: [],
-      };
-      const action = {
-        type: actions.CANCEL_EDITING,
-      };
-
-      expect(uiReducer(state, action)).to.deep.equal({
-        editing: false,
-        newItem: false,
         selectedItemId: null,
         filter: [],
       });
@@ -379,7 +364,6 @@ describe("reducers", () => {
     it("handle ADD_ITEM_COMPLETED", () => {
       const state = {
         editing: true,
-        newItem: true,
         selectedItemId: null,
         filter: [],
       };
@@ -392,7 +376,6 @@ describe("reducers", () => {
 
       expect(uiReducer(state, action)).to.deep.equal({
         editing: false,
-        newItem: false,
         selectedItemId: "1",
         filter: [],
       });
@@ -401,7 +384,6 @@ describe("reducers", () => {
     it("handle UPDATE_ITEM_COMPLETED", () => {
       const state = {
         editing: true,
-        newItem: false,
         selectedItemId: "1",
         filter: [],
       };
@@ -411,7 +393,6 @@ describe("reducers", () => {
 
       expect(uiReducer(state, action)).to.deep.equal({
         editing: false,
-        newItem: false,
         selectedItemId: "1",
         filter: [],
       });
@@ -420,7 +401,6 @@ describe("reducers", () => {
     it("handle SELECT_ITEM_STARTING", () => {
       const state = {
         editing: true,
-        newItem: true,
         selectedItemId: null,
         filter: [],
       };
@@ -431,7 +411,64 @@ describe("reducers", () => {
 
       expect(uiReducer(state, action)).to.deep.equal({
         editing: false,
-        newItem: false,
+        selectedItemId: "1",
+        filter: [],
+      });
+    });
+
+    it("handle START_NEW_ITEM", () => {
+      const action = {
+        type: actions.START_NEW_ITEM,
+      };
+
+      expect(uiReducer(undefined, action)).to.deep.equal({
+        editing: true,
+        selectedItemId: NEW_ITEM_ID,
+        filter: [],
+      });
+    });
+
+    it("handle EDIT_CURRENT_ITEM", () => {
+      const action = {
+        type: actions.EDIT_CURRENT_ITEM,
+      };
+
+      expect(uiReducer(undefined, action)).to.deep.equal({
+        editing: true,
+        selectedItemId: null,
+        filter: [],
+      });
+    });
+
+    it("handle CANCEL_EDITING (new item)", () => {
+      const state = {
+        editing: true,
+        selectedItemId: NEW_ITEM_ID,
+        filter: [],
+      };
+      const action = {
+        type: actions.CANCEL_EDITING,
+      };
+
+      expect(uiReducer(state, action)).to.deep.equal({
+        editing: false,
+        selectedItemId: null,
+        filter: [],
+      });
+    });
+
+    it("handle CANCEL_EDITING (existing item)", () => {
+      const state = {
+        editing: true,
+        selectedItemId: "1",
+        filter: [],
+      };
+      const action = {
+        type: actions.CANCEL_EDITING,
+      };
+
+      expect(uiReducer(state, action)).to.deep.equal({
+        editing: false,
         selectedItemId: "1",
         filter: [],
       });
@@ -439,7 +476,8 @@ describe("reducers", () => {
 
     it("handle FILTER_ITEMS", () => {
       const state = {
-        newItem: false,
+        editing: false,
+        selectedItemId: null,
         filter: [],
       };
       const action = {
@@ -448,7 +486,8 @@ describe("reducers", () => {
       };
 
       expect(uiReducer(state, action)).to.deep.equal({
-        newItem: false,
+        editing: false,
+        selectedItemId: null,
         filter: ["my filter"],
       });
     });

--- a/test/manage/reducers-test.js
+++ b/test/manage/reducers-test.js
@@ -324,6 +324,7 @@ describe("reducers", () => {
   describe("ui reducer", () => {
     it("initial state", () => {
       expect(uiReducer(undefined, {})).to.deep.equal({
+        editing: false,
         newItem: false,
         selectedItemId: null,
         filter: [],
@@ -336,23 +337,39 @@ describe("reducers", () => {
       };
 
       expect(uiReducer(undefined, action)).to.deep.equal({
+        editing: true,
         newItem: true,
         selectedItemId: null,
         filter: [],
       });
     });
 
-    it("handle CANCEL_NEW_ITEM", () => {
+    it("handle EDIT_CURRENT_ITEM", () => {
+      const action = {
+        type: actions.EDIT_CURRENT_ITEM,
+      };
+
+      expect(uiReducer(undefined, action)).to.deep.equal({
+        editing: true,
+        newItem: false,
+        selectedItemId: null,
+        filter: [],
+      });
+    });
+
+    it("handle CANCEL_EDITING", () => {
       const state = {
+        editing: true,
         newItem: true,
         selectedItemId: null,
         filter: [],
       };
       const action = {
-        type: actions.CANCEL_NEW_ITEM,
+        type: actions.CANCEL_EDITING,
       };
 
       expect(uiReducer(state, action)).to.deep.equal({
+        editing: false,
         newItem: false,
         selectedItemId: null,
         filter: [],
@@ -361,6 +378,7 @@ describe("reducers", () => {
 
     it("handle ADD_ITEM_COMPLETED", () => {
       const state = {
+        editing: true,
         newItem: true,
         selectedItemId: null,
         filter: [],
@@ -373,6 +391,26 @@ describe("reducers", () => {
       };
 
       expect(uiReducer(state, action)).to.deep.equal({
+        editing: false,
+        newItem: false,
+        selectedItemId: "1",
+        filter: [],
+      });
+    });
+
+    it("handle UPDATE_ITEM_COMPLETED", () => {
+      const state = {
+        editing: true,
+        newItem: false,
+        selectedItemId: "1",
+        filter: [],
+      };
+      const action = {
+        type: actions.UPDATE_ITEM_COMPLETED,
+      };
+
+      expect(uiReducer(state, action)).to.deep.equal({
+        editing: false,
         newItem: false,
         selectedItemId: "1",
         filter: [],
@@ -381,7 +419,8 @@ describe("reducers", () => {
 
     it("handle SELECT_ITEM_STARTING", () => {
       const state = {
-        newItem: false,
+        editing: true,
+        newItem: true,
         selectedItemId: null,
         filter: [],
       };
@@ -391,6 +430,7 @@ describe("reducers", () => {
       };
 
       expect(uiReducer(state, action)).to.deep.equal({
+        editing: false,
         newItem: false,
         selectedItemId: "1",
         filter: [],


### PR DESCRIPTION
The plan here is to change the item details so that we're not *always* editing them. From the "view" mode, you can click Edit or Delete, and then in "edit" mode, you can edit the fields, Save, or Cancel.

This will also make auto-focusing the first form field in the editor easier, since it won't interrupt you when navigating through the list of items. Finally, I added a "new item" placeholder in the item list, since I think that should make it clearer what's going on for users.