### PR TITLE
Attempt to register and record Event Telemetry

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -4,8 +4,21 @@
 
 /* eslint-disable no-unused-vars */
 
+Components.utils.import("resource://gre/modules/Services.jsm");
+
 function startup({webExtension}, reason) {
+  Services.telemetry.registerEvents("lockbox", {
+    "startup": {
+      methods: ["startup"],
+      objects: ["addon", "webextension"],
+    },
+    "click": {
+      methods: ["click"],
+      objects: ["browser_action"],
+    },
+  });
   webExtension.startup().then(() => {
+    Services.telemetry.recordEvent("lockbox", "startup", "webextension", null, null);
     console.log("embedded webextension has started");
   });
 }


### PR DESCRIPTION
@jimporter @linuxwolf I was looking over the new add-on "Event Telemetry" stuff and attempted to register and record an event to pave the way for #70:

- https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#registerevents
- https://blog.mozilla.org/data/2017/09/18/recording-new-telemetry-from-add-ons/

With this code I don't get any errors (from what I can tell) but I also don't see any "Events" in `about:telemetry`. 

Can you tell if I've done something wrong? 