### PR TITLE
Output addon.env at build for Jenkins pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node_modules/
 /site/
 /*.xpi
+addon.env

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,7 +13,11 @@ To **prepare the extension for a new version**, you must:
 To **build a signed extension .xpi**, you must: commit and push to the
 `production` branch (ideally as a merge commit from `master`) on GitHub.
 
-##
+## Extension Signing
 
-Learn more about the deployment and hosting process here:
+Learn about the Test Pilot extension deployment and hosting process here:  
 https://github.com/mozilla/testpilot/blob/master/docs/development/hosting.md
+
+This repository is in the "testpilot-mozillaextension" Jenkins pipeline.
+The CloudOps team manages access to, and can help report on, the status of the
+builds.

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "pretest": "npm run-script autolint",
     "test": "cross-env NODE_ENV=test nyc mocha-webpack --opts ./mocha-webpack.opts --webpack-config ./webpack.config.test.js -r test/setup.js test",
     "codecov": "nyc report --reporter=lcov && codecov",
-    "clean": "git clean -fX ./dist ./*.xpi && npm run :clean:doc ",
+    "clean": "git clean -fX ./dist ./*.xpi ./addon.env && npm run :clean:doc ",
     "distclean": "git clean -dfX",
     "prepackage": "npm run-script clean && cross-env NODE_ENV=production npm run-script build",
-    "package": "cd dist && nodezip -c ../addon.xpi *"
+    "package": "echo 'TESTPILOT_ADDON_ID='${npm_package_id}'\nTESTPILOT_ADDON_VERSION='${npm_package_version} > addon.env && cd dist && nodezip -c ../addon.xpi *"
   },
   "nyc": {
     "all": true,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "git clean -fX ./dist ./*.xpi && npm run :clean:doc ",
     "distclean": "git clean -dfX",
     "prepackage": "npm run-script clean && cross-env NODE_ENV=production npm run-script build",
-    "package": "jpm xpi --addon-dir dist/ --dest-dir . && mv lockbox.xpi addon.xpi"
+    "package": "cd dist && nodezip -c ../addon.xpi *"
   },
   "nyc": {
     "all": true,
@@ -106,6 +106,7 @@
     "json-templater": "^1.1.0",
     "mocha": "^3.5.3",
     "mocha-webpack": "^1.0.0-rc.1",
+    "node-zip": "^1.1.1",
     "nyc": "^11.2.1",
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "^15.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "git clean -fX ./dist ./*.xpi ./addon.env && npm run :clean:doc ",
     "distclean": "git clean -dfX",
     "prepackage": "npm run-script clean && cross-env NODE_ENV=production npm run-script build",
-    "package": "echo 'TESTPILOT_ADDON_ID='${npm_package_id}'\nTESTPILOT_ADDON_VERSION='${npm_package_version} > addon.env && cd dist && nodezip -c ../addon.xpi *"
+    "package": "echo TESTPILOT_ADDON_ID=${npm_package_id} > addon.env && echo TESTPILOT_ADDON_VERSION=${npm_package_version} >> addon.env && cd dist && nodezip -c ../addon.xpi *"
   },
   "nyc": {
     "all": true,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "git clean -fX ./dist ./*.xpi && npm run :clean:doc ",
     "distclean": "git clean -dfX",
     "prepackage": "npm run-script clean && cross-env NODE_ENV=production npm run-script build",
-    "package": "cd dist && nodezip -c ../addon.xpi *"
+    "package": "jpm xpi --addon-dir dist/ --dest-dir . && mv lockbox.xpi addon.xpi"
   },
   "nyc": {
     "all": true,
@@ -106,7 +106,6 @@
     "json-templater": "^1.1.0",
     "mocha": "^3.5.3",
     "mocha-webpack": "^1.0.0-rc.1",
-    "node-zip": "^1.1.1",
     "nyc": "^11.2.1",
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "^15.6.0",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -91,6 +91,7 @@ export default {
 
   plugins: [
     new CopyWebpackPlugin([
+      {from: "../package.json"},
       {from: "bootstrap.js"},
       {from: "webextension/locales/**/*.ftl"},
       {from: "webextension/icons/*"},

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -91,7 +91,6 @@ export default {
 
   plugins: [
     new CopyWebpackPlugin([
-      {from: "../package.json"},
       {from: "bootstrap.js"},
       {from: "webextension/locales/**/*.ftl"},
       {from: "webextension/icons/*"},


### PR DESCRIPTION
This way pipeline scripts looking for a package.json (addon) _or_ manifest.json (WebExtension) find what they're looking for (Test Pilot signing)

And switch to using jpm to build the xpi since it does what we need and we already have it, so no need for a zip dependency

Related to #25 #26 

---

Once this merges I'll attempt another build on `production` and check the Jenkins result