### PR TITLE
Bump version to 0.1.0pre1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lockbox",
-  "version": "0.1.0-pre",
+  "version": "0.1.0pre1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "title": "Lockbox",
   "name": "lockbox",
   "id": "lockbox@mozilla.com",
-  "version": "0.1.0-pre",
+  "version": "0.1.0pre1",
   "main": "dist/bootstrap.js",
   "description": "A Lockbox extension for Firefox",
   "author": "Lockbox Team <lockbox@mozilla.com>",


### PR DESCRIPTION
Turns out hyphens don't meet Toolkit version format spec
https://developer.mozilla.org/en-US/docs/Toolkit_version_format

And I want to confirm bumping the version then properly updates the `updates.json` hosted by Test Pilot and the browser does then fetch and update the addon.

If this all works, this helps finish up #26 🎉 