### PR TITLE
Add telemetry

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,7 @@
     "test": {
       "plugins": [
         "istanbul",
+        "rewire",
         "transform-runtime"
       ]
     }

--- a/jpm-prefs.json
+++ b/jpm-prefs.json
@@ -1,4 +1,6 @@
 {
+  "toolkit.telemetry.enabled": true,
+  "toolkit.telemetry.server": "https://127.0.0.1/telemetry-dummy/",
   "xpinstall.signatures.required": false,
   "extensions.legacy.enabled": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -286,7 +286,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -1103,6 +1103,12 @@
         "istanbul-lib-instrument": "1.7.5",
         "test-exclude": "4.1.1"
       }
+    },
+    "babel-plugin-rewire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-rewire/-/babel-plugin-rewire-1.1.0.tgz",
+      "integrity": "sha1-prlm2djAbAPZXc2i7sTiUhUZVJs=",
+      "dev": true
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -3077,7 +3083,6 @@
       "requires": {
         "anymatch": "1.3.0",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -6284,910 +6289,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50="
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
@@ -7461,7 +6562,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globals-docs": {
@@ -7752,7 +6853,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "html": {
@@ -10304,13 +9405,6 @@
         }
       }
     },
-    "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-      "dev": true,
-      "optional": true
-    },
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
@@ -10502,7 +9596,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -13565,7 +12659,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "2.0.6"
       }
@@ -13672,7 +12766,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -14514,7 +13608,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "safe-json-parse": {
@@ -14840,7 +13934,7 @@
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+      "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU="
     },
     "source-map": {
       "version": "0.5.6",
@@ -16613,7 +15707,7 @@
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "integrity": "sha1-xzVkNqTRMSO+LiQmoF0drZy+Zc8=",
       "dev": true,
       "requires": {
         "source-list-map": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "babel-loader": "^7.1.2",
     "babel-minify-webpack-plugin": "^0.2.0",
     "babel-plugin-istanbul": "^4.1.5",
+    "babel-plugin-rewire": "^1.1.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -4,9 +4,36 @@
 
 /* eslint-disable no-unused-vars */
 
+const { utils: Cu } = Components;
+
+Cu.import("resource://gre/modules/Services.jsm");
+
 function startup({webExtension}, reason) {
-  webExtension.startup().then(() => {
+  Services.telemetry.registerEvents("lockbox", {
+    "startup": {
+      methods: ["startup"],
+      objects: ["addon", "webextension"],
+    },
+    "click": {
+      methods: ["click"],
+      objects: ["browser_action"],
+      extra_keys: ["fxauid"],
+    },
+  });
+
+  webExtension.startup().then(({browser}) => {
     console.log("embedded webextension has started");
+    Services.telemetry.recordEvent("lockbox", "startup", "webextension");
+    browser.runtime.onMessage.addListener((message, sender, respond) => {
+      switch (message.type) {
+      case "telemetry_event":
+        Services.telemetry.recordEvent(
+          message.category, message.method, message.object, null,
+          message.extra || null
+        );
+        respond({});
+      }
+    });
   });
 }
 

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -40,3 +40,10 @@ function startup({webExtension}, reason) {
 function shutdown(data, reason) {}
 function install(data, reason) {}
 function uninstall(data, reason) {}
+
+// We need to reference these functions so that babel-plugin-rewire can see
+// them for our tests.
+startup;
+shutdown;
+install;
+uninstall;

--- a/src/webextension/background/browser-action.js
+++ b/src/webextension/background/browser-action.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { openView } from "./views";
+import * as telemetry from "./telemetry";
 
 let listener;
 let popup;
@@ -13,6 +14,7 @@ function installPopup(path) {
     popup,
   });
 }
+
 function uninstallPopup() {
   if (popup) {
     browser.browserAction.setPopup({ popup: "" });
@@ -21,9 +23,13 @@ function uninstallPopup() {
 }
 
 function installListener(name) {
-  listener = () => { openView(name); };
+  listener = () => {
+    telemetry.recordEvent("lockbox", "click", "browser_action");
+    openView(name);
+  };
   browser.browserAction.onClicked.addListener(listener);
 }
+
 function uninstallListener() {
   if (listener) {
     browser.browserAction.onClicked.removeListener(listener);

--- a/src/webextension/background/message-ports.js
+++ b/src/webextension/background/message-ports.js
@@ -5,6 +5,7 @@
 import openDataStore from "./datastore";
 import getAuthorization, { saveAuthorization } from "./authorization/index";
 import updateBrowserAction from "./browser-action";
+import * as telemetry from "./telemetry";
 import { openView, closeView } from "./views";
 import { makeItemSummary } from "../common";
 
@@ -24,7 +25,7 @@ export default function initializeMessagePorts() {
     port.onDisconnect.addListener(() => ports.delete(port));
   });
 
-  browser.runtime.onMessage.addListener(async function(message, sender) {
+  browser.runtime.onMessage.addListener(async(message, sender) => {
     switch (message.type) {
     case "open_view":
       return openView(message.name).then(() => ({}));
@@ -90,8 +91,13 @@ export default function initializeMessagePorts() {
       return openDataStore().then(async(ds) => {
         return {item: await ds.get(message.id)};
       });
+
+    case "proxy_telemetry_event":
+      return telemetry.recordEvent(
+        message.category, message.method, message.object, message.extra
+      );
     default:
-      throw new Error(`unknown message type "${message.type}`);
+      return null;
     }
   });
 }

--- a/src/webextension/background/telemetry.js
+++ b/src/webextension/background/telemetry.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import getAuthorization from "./authorization/index";
+
+export async function recordEvent(category, method, object, extra) {
+  const fxauid = getAuthorization().uid;
+  if (fxauid) {
+    extra = {...(extra || {}), fxauid};
+  }
+
+  return browser.runtime.sendMessage({
+    type: "telemetry_event", category, method, object, extra,
+  });
+}

--- a/src/webextension/telemetry.js
+++ b/src/webextension/telemetry.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export async function recordEvent(category, method, object, extra) {
+  return browser.runtime.sendMessage({
+    type: "proxy_telemetry_event", category, method, object, extra,
+  });
+}

--- a/test/background/browser-action-test.js
+++ b/test/background/browser-action-test.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+import updateBrowserAction from
+       "../../src/webextension/background/browser-action";
+
+describe("background > browser action", () => {
+  let openView;
+
+  beforeEach(() => {
+    openView = sinon.spy();
+    updateBrowserAction.__Rewire__("openView", openView);
+  });
+
+  afterEach(() => {
+    updateBrowserAction.__ResetDependency__("openView");
+  });
+
+  it("uninitialized data store", async() => {
+    await updateBrowserAction({initialized: false});
+    browser.browserAction.onClicked.mockFireListener();
+    expect(openView).to.have.been.calledWith("firstrun");
+  });
+
+  it("locked data store", async() => {
+    await updateBrowserAction({initialized: true, locked: true});
+    expect(browser.browserAction.getPopup()).to.eventually.equal(
+      browser.extension.getURL("popup/unlock/index.html")
+    );
+  });
+
+  it("unlocked data store", async() => {
+    await updateBrowserAction({initialized: true, locked: false});
+    browser.browserAction.onClicked.mockFireListener();
+    expect(openView).to.have.been.calledWith("manage");
+  });
+});

--- a/test/background/message-ports-test.js
+++ b/test/background/message-ports-test.js
@@ -199,9 +199,10 @@ describe("message ports (background side)", () => {
   });
 
   it("handle unknown message type", async() => {
-    await expect(browser.runtime.sendMessage({
+    const result = await browser.runtime.sendMessage({
       type: "nonexist",
-    })).to.be.rejectedWith(Error);
+    });
+    expect(result).to.equal(null);
   });
 
   it("handle message port disconnect", async() => {

--- a/test/background/message-ports-test.js
+++ b/test/background/message-ports-test.js
@@ -198,6 +198,23 @@ describe("message ports (background side)", () => {
     });
   });
 
+  it('handle "proxy_telemetry_event"', async() => {
+    const recordEvent = sinon.stub().resolves({});
+    initializeMessagePorts.__Rewire__("telemetry", {recordEvent});
+    const result = await browser.runtime.sendMessage({
+      type: "proxy_telemetry_event",
+      category: "category",
+      method: "method",
+      object: "object",
+      extra: {extra: "value"},
+    });
+    initializeMessagePorts.__ResetDependency__("telemetry");
+
+    expect(result).to.deep.equal({});
+    expect(recordEvent).to.have.been.calledWith("category", "method", "object",
+                                                {extra: "value"});
+  });
+
   it("handle unknown message type", async() => {
     const result = await browser.runtime.sendMessage({
       type: "nonexist",

--- a/test/background/telemetry-test.js
+++ b/test/background/telemetry-test.js
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import chai, { expect } from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+chai.use(sinonChai);
+
+import getAuthorization from "../../src/webextension/background/authorization";
+import * as telemetry from "../../src/webextension/background/telemetry";
+
+describe("background - telemetry", () => {
+  let onMessage;
+
+  beforeEach(() => {
+    browser.runtime.onMessage.addListener(onMessage = sinon.stub().returns({}));
+  });
+
+  afterEach(() => {
+    browser.runtime.onMessage.mockClearListener();
+  });
+
+  describe("no fxa uid", () => {
+    it("recordEvent()", async() => {
+      const result = await telemetry.recordEvent("category", "method",
+                                                 "object");
+      expect(result).to.deep.equal({});
+      expect(onMessage).to.have.been.calledWith({
+        type: "telemetry_event",
+        category: "category",
+        method: "method",
+        object: "object",
+        extra: undefined,
+      });
+    });
+
+    it("recordEvent() with extra", async() => {
+      const result = await telemetry.recordEvent("category", "method", "object",
+                                                 {extra: "value"});
+      expect(result).to.deep.equal({});
+      expect(onMessage).to.have.been.calledWith({
+        type: "telemetry_event",
+        category: "category",
+        method: "method",
+        object: "object",
+        extra: {extra: "value"},
+      });
+    });
+  });
+
+  describe("with fxa uid", () => {
+    before(() => {
+      // Pretend we're signed in.
+      getAuthorization().info = {
+        uid: "1234",
+      };
+    });
+
+    after(() => {
+      getAuthorization().info = undefined;
+    });
+
+    it("recordEvent() (with fxa uid)", async() => {
+      const result = await telemetry.recordEvent("category", "method",
+                                                 "object");
+      expect(result).to.deep.equal({});
+      expect(onMessage).to.have.been.calledWith({
+        type: "telemetry_event",
+        category: "category",
+        method: "method",
+        object: "object",
+        extra: {fxauid: "1234"},
+      });
+    });
+
+    it("recordEvent() (with fxa uid and extras)", async() => {
+      const result = await telemetry.recordEvent("category", "method", "object",
+                                                 {extra: "value"});
+      expect(result).to.deep.equal({});
+      expect(onMessage).to.have.been.calledWith({
+        type: "telemetry_event",
+        category: "category",
+        method: "method",
+        object: "object",
+        extra: {extra: "value", fxauid: "1234"},
+      });
+    });
+  });
+});

--- a/test/bootstrap-test.js
+++ b/test/bootstrap-test.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import waitUntil from "async-wait-until";
+import chai, { expect } from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+chai.use(sinonChai);
+
+import bootstrap from "../src/bootstrap";
+
+describe("bootstrap", () => {
+  it("startup()", async() => {
+    const startup = bootstrap.__get__("startup");
+    const webextStartup = sinon.stub().resolves({browser});
+    startup({webExtension: {
+      startup: webextStartup,
+    }});
+
+    await waitUntil(() => webextStartup.callCount === 1);
+    const result = await browser.runtime.sendMessage({type: "telemetry_event"});
+    expect(result).to.deep.equal({});
+  });
+
+  // These functions are currently no-ops, so we just need to test that they
+  // exist.
+
+  it("shutdown()", () => {
+    const shutdown = bootstrap.__get__("shutdown");
+    shutdown();
+  });
+
+  it("install()", () => {
+    const install = bootstrap.__get__("install");
+    install();
+  });
+
+  it("uninstall()", () => {
+    const uninstall = bootstrap.__get__("uninstall");
+    uninstall();
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -50,6 +50,12 @@ class MockListener {
     this._listener = fn;
   }
 
+  removeListener(fn) {
+    if (fn === this._listener) {
+      this._listener = null;
+    }
+  }
+
   mockClearListener() {
     this._listener = null;
   }
@@ -120,11 +126,16 @@ function makePairedPorts(contextId) {
 
 global.browser = {
   browserAction: {
-    onClicked: {
-      addListener() {},
-      removeListener() {},
+    _popupPage: "",
+    onClicked: new MockListener(),
+
+    setPopup({popup}) {
+      this._popupPage = popup;
     },
-    setPopup() {},
+
+    async getPopup() {
+      return this._popupPage;
+    },
   },
 
   extension: {

--- a/test/telemetry-test.js
+++ b/test/telemetry-test.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import chai, { expect } from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+chai.use(sinonChai);
+
+import * as telemetry from "../src/webextension/telemetry";
+
+describe("telemetry", () => {
+  let onMessage;
+
+  beforeEach(() => {
+    browser.runtime.onMessage.addListener(onMessage = sinon.stub().returns({}));
+  });
+
+  afterEach(() => {
+    browser.runtime.onMessage.mockClearListener();
+  });
+
+  it("recordEvent()", async() => {
+    const result = await telemetry.recordEvent("category", "method", "object",
+                                               {extra: "value"});
+    expect(result).to.deep.equal({});
+    expect(onMessage).to.have.been.calledWith({
+      type: "proxy_telemetry_event",
+      category: "category",
+      method: "method",
+      object: "object",
+      extra: {extra: "value"},
+    });
+  });
+});


### PR DESCRIPTION
(Only the last commit is relevant.)

@linuxwolf This is a rough sketch of what I'm thinking about for Telemetry. The goal is to have a simple API that looks like the XPCOM Telemetry API, since that should hopefully make it easy to convert to WebExtension-based Telemetry if/when we get it.

Some extra stuff that might be worth doing:
* Defining our events in a separate JSON file?
* Making a similar API for our background script events? This might make sender-side error-detection easier.