### PR TITLE
Ignore coverage to prevent CI warnings on report

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 !.eslintrc.js
+coverage
 dist
-site
 node_modules
+site
 temp


### PR DESCRIPTION
Builds on tags run `npm run package` after codecov has run (to build the XPI and add it to GitHub Releases).

But package runs eslint. And eslint then runs against the "coverage" directory?

https://travis-ci.org/mozilla-lockbox/lockbox-extension/builds/284306037#L4257

Would this change to ignore prevent all those warnings? ☝️ 