### PR TITLE
Start a very simple lock button

### DIFF
--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -1,5 +1,6 @@
 add-item = Add Item
 go-home = Home
+lock-it = Sign Out
 
 item-filter.placeholder = Filter…
 

--- a/src/webextension/manage/components/app.js
+++ b/src/webextension/manage/components/app.js
@@ -8,6 +8,7 @@ import AddItem from "../containers/add-item";
 import AllItems from "../containers/all-items";
 import CurrentSelection from "../containers/current-selection";
 import GoHome from "../containers/go-home";
+import LockIt from "../containers/lock-it";
 import ItemFilter from "../containers/item-filter";
 import ModalRoot from "../containers/modal-root";
 
@@ -25,6 +26,7 @@ export default function App() {
           <menu>
             <AddItem/>
             <GoHome/>
+            <LockIt/>
           </menu>
           <CurrentSelection/>
         </article>

--- a/src/webextension/manage/containers/lock-it.js
+++ b/src/webextension/manage/containers/lock-it.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Localized } from "fluent-react";
+import PropTypes from "prop-types";
+import React from "react";
+import { connect } from "react-redux";
+
+import Button from "../../widgets/button";
+import { selectItem } from "../actions";
+
+function LockIt({dispatch}) {
+  return (
+    <Localized id="lock-it">
+      <Button onClick={() => { browser.runtime.sendMessage({type: "lock"});
+                               browser.tabs.reload(); }}>
+        siGn oUT
+      </Button>
+    </Localized>
+  );
+}
+
+LockIt.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+};
+
+export default connect()(LockIt);

--- a/src/webextension/manage/containers/lock-it.js
+++ b/src/webextension/manage/containers/lock-it.js
@@ -8,13 +8,14 @@ import React from "react";
 import { connect } from "react-redux";
 
 import Button from "../../widgets/button";
-import { selectItem } from "../actions";
 
 function LockIt({dispatch}) {
   return (
     <Localized id="lock-it">
-      <Button onClick={() => { browser.runtime.sendMessage({type: "lock"});
-                               browser.tabs.reload(); }}>
+      <Button onClick={() => {
+                                browser.runtime.sendMessage({ type: "lock" });
+                                browser.tabs.reload();
+                              }}>
         siGn oUT
       </Button>
     </Localized>


### PR DESCRIPTION
Fixes #149

A very quick solution to let the user manually "Lock" or "Sign Out" requiring the user to enter their password again.

I also threw in a reload on the current view just so the user isn't confused why they can still see their passwords. Not great but a start.

![lock-it](https://user-images.githubusercontent.com/49511/31362873-10bab242-ad18-11e7-8ffb-cc100139b82d.gif)

Some of the concern at #151 (multiple sessions/tabs) comes into play here (user has 3 tabs open, sees items still in two of them, loses trust their data is secure/locked). I'd rather _not_ start any of that decision making/code before Alpha and instead get this work-able and trust-able.