### PR TITLE
Add release instructions

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -7,9 +7,10 @@
   - Alpha releases will be tagged with "-alpha" (e.g., "0.1.0-alpha")
   - Beta releases will be tagged with "-beta" (e.g., "0.x.0-beta")
   - Stable releases will **not** be tagged, and follow smever from the last Beta release (major, minor, and patch)
-2. Update "CHANGELOG.md" using `conventional-changelog`
-  - we follow the "angular" convention
-  - review the resulting output in case anything is missed, unexpected, etc.
+2. Update "release-notes.md"
+  - latest release goes to the top, under a second-level header
+  - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"
+  - consult with Product Management
 2. Commit and ultimately merge to "master" branch
 3. Merge and push "master" branch to "production" branch
   - `git checkout master`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -55,13 +55,13 @@ To generate the next release binary:
 Learn about the Test Pilot extension deployment and hosting process here:  
 https://github.com/mozilla/testpilot/blob/master/docs/development/hosting.md
 
-This repository is in the "testpilot-mozillaextension" Jenkins pipeline.
+This repository is in the **"testpilot-mozillaextension"** Jenkins pipeline.
 The CloudOps team manages access to, and can help report on, the status of the
 builds.
 
 The resulting files deployed are:
 
-- Updates file for automatic browser extension updates: https://testpilot.firefox.com/files/lockbox@mozilla.com/updates.json
-- Latest version of the signed extension XPI: https://testpilot.firefox.com/files/lockbox@mozilla.com/latest
+- Updates file for automatic browser extension updates: [https://testpilot.firefox.com/files/lockbox@mozilla.com/updates.json](https://testpilot.firefox.com/files/lockbox@mozilla.com/updates.json)
+- Latest version of the signed extension XPI: [https://testpilot.firefox.com/files/lockbox@mozilla.com/latest](https://testpilot.firefox.com/files/lockbox@mozilla.com/latest)
 
-**IMPORTANT** Join the IRC channel **#testpilot-bots** for updates on the status of these builds prior to pushing the `production` branch to GitHub.
+**IMPORTANT:** Test Pilot reports the status of build, signing, and deployment of its artifacts on the IRC channel **#testpilot-bots**.  Be sure to join the channel prior to pushing the `production` branch to GitHub in order to receive the status updates.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,9 +11,31 @@ To **prepare the extension for a new version**, you must:
 ## Packaging
 
 To **build a signed extension .xpi**, you must: commit and push to the
-`production` branch (ideally as a merge commit from `master`) on GitHub.
+`production` branch (ideally as a merge from `master`) on GitHub.
 
-## Extension Signing
+### Instructions
+
+1. Update "version" in package.json (and package-lock.json)
+2. Update "CHANGELOG.md" using `conventional-changelog`
+2. Commit and ultimately merge to "master" branch
+3. Merge and push "master" branch to "production" branch
+  - `git checkout master`
+  - `git pull` (to make sure you have the latest)
+  - `git checkout production`
+  - `git pull` (to make sure you have the latest)
+  - `git merge master`
+  - `git push`
+  - Jenkins will now build and sign the extension (see "Extension Signing")
+4. Tag the production branch at the version
+  - `git tag 0.1.0`
+  - `git push --tags`
+  - Travis CI will build and generate a GitHub Release
+7. Edit the resulting GitHub Release
+  - Set the GitHub Release title to match the version
+  - Set the notes to match the CHANGELOG
+  - Download the `signed-addon.xpi` and attach it to the release
+
+### Extension Signing
 
 Learn about the Test Pilot extension deployment and hosting process here:  
 https://github.com/mozilla/testpilot/blob/master/docs/development/hosting.md
@@ -21,3 +43,10 @@ https://github.com/mozilla/testpilot/blob/master/docs/development/hosting.md
 This repository is in the "testpilot-mozillaextension" Jenkins pipeline.
 The CloudOps team manages access to, and can help report on, the status of the
 builds.
+
+The resulting files deployed are:
+
+- Updates file for automatic browser extension updates: https://testpilot.firefox.com/files/lockbox@mozilla.com/updates.json
+- Latest version of the signed extension XPI: https://testpilot.firefox.com/files/lockbox@mozilla.com/latest
+
+Join #testpilot-bots in IRC for updates on the status of builds.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,10 +3,10 @@
 ### Instructions
 
 1. Update "version" in package.json (and package-lock.json)
-  - we follow the [semver](http://semver.org/) convention
-  - versions "0.1.0" to "1.0.0" is reserved for the internal Alpha
-  - version "1.0.0" is reserved for a public Beta
-  - major, minor, and patch releases will follow semver from there
+  - we follow the [semver](http://semver.org/) syntax
+  - Alpha releases will be tagged with "-alpha" (e.g., "0.1.0-alpha")
+  - Beta releases will be tagged with "-beta" (e.g., "0.x.0-beta")
+  - Stable releases will **not** be tagged, and follow smever from the last Beta release (major, minor, and patch)
 2. Update "CHANGELOG.md" using `conventional-changelog`
   - we follow the "angular" convention
   - review the resulting output in case anything is missed, unexpected, etc.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,31 +3,31 @@
 ### Instructions
 
 1. Update "version" in package.json (and package-lock.json)
-  - we follow the [semver](http://semver.org/) syntax
-  - Alpha releases will be tagged with "-alpha" (e.g., "0.1.0-alpha")
-  - Beta releases will be tagged with "-beta" (e.g., "0.x.0-beta")
-  - Stable releases will **not** be tagged, and follow smever from the last Beta release (major, minor, and patch)
+    - we follow the [semver](http://semver.org/) syntax
+    - Alpha releases will be tagged with "-alpha" (e.g., "0.1.0-alpha")
+    - Beta releases will be tagged with "-beta" (e.g., "0.x.0-beta")
+    - Stable releases will **not** be tagged, and follow smever from the last Beta release (major, minor, and patch)
 2. Update "release-notes.md"
-  - latest release goes to the top, under a second-level header
-  - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"
-  - consult with Product Management
+    - latest release goes to the top, under a second-level header
+    - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"
+    - consult with Product Management
 2. Commit and ultimately merge to "master" branch
 3. Merge and push "master" branch to "production" branch
-  - `git checkout master`
-  - `git pull` (to make sure you have the latest)
-  - `git checkout production`
-  - `git pull` (to make sure you have the latest)
-  - `git merge master`
-  - `git push`
-  - Jenkins will now build and sign the extension (see "Extension Signing")
+    - `git checkout master`
+    - `git pull` (to make sure you have the latest)
+    - `git checkout production`
+    - `git pull` (to make sure you have the latest)
+    - `git merge master`
+    - `git push`
+    - Jenkins will now build and sign the extension (see "Extension Signing")
 4. Tag the production branch at the version
-  - `git tag 0.1.0`
-  - `git push --tags`
-  - Travis CI will build and generate a GitHub Release
+    - `git tag 0.1.0`
+    - `git push --tags`
+    - Travis CI will build and generate a GitHub Release
 7. Edit the resulting GitHub Release
-  - Set the GitHub Release title to match the version
-  - Set the notes to match the CHANGELOG
-  - Download the `signed-addon.xpi` and attach it to the release
+    - Set the GitHub Release title to match the version
+    - Set the notes to match the CHANGELOG
+    - Download the `signed-addon.xpi` and attach it to the release
 
 ### Extension Signing
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -32,7 +32,10 @@
 7. Edit the resulting GitHub Release
     - Set the GitHub Release title to match the version
     - Set the notes to match the `docs/release-notes.md`
-    - Download the `signed-addon.xpi` and attach it to the release
+    - Download the `signed-addon.xpi`
+        - `wget -O signed-addon.xpi https://testpilot.firefox.com/files/lockbox@mozilla.com/latest`
+    - Attach it to the release
+
 
 ### Extension Signing
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,11 @@
 ## Releases
 
+### Checklist
+
+* Unfinished work has been triaged and assigned to the appropriate milestone
+* Finished work is verified on `master`
+* Product, Engineering, and PI have signed-off on releasing
+
 ### Instructions
 
 **NOTE:** These instructions assume:
@@ -15,7 +21,7 @@
 2. Update `docs/release-notes.md`
     - latest release goes to the top, under a second-level header
     - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"
-    - consult with Product Management
+    - consult with Product Management on wording if needed
 2. Commit and ultimately merge to "master" branch
 3. Merge and push "master" branch to "production" branch
     - `git checkout master`
@@ -35,6 +41,7 @@
     - Download the `signed-addon.xpi`
         - `wget -O signed-addon.xpi https://testpilot.firefox.com/files/lockbox@mozilla.com/latest`
     - Attach it to the release
+8. Announcement sent to the team that all steps are complete (e.g., via Slack team channel)
 
 
 ### Extension Signing

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,7 @@
 
 Before a release can be made, the following must be done:
 
+* Any user stories labeled as `epic` to be included in the release are approved by Product and PI
 * All finished work is verified to work as expected and committed to `master`
 * Any unfinished work has been triaged and assigned to the appropriate milestone
 * Product, Engineering, and PI have voiced approval to release (e.g., via Slack team channel)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,8 @@
   - version "1.0.0" is reserved for a public Beta
   - major, minor, and patch releases will follow semver from there
 2. Update "CHANGELOG.md" using `conventional-changelog`
+  - we follow the "angular" convention
+  - review the resulting output in case anything is missed, unexpected, etc.
 2. Commit and ultimately merge to "master" branch
 3. Merge and push "master" branch to "production" branch
   - `git checkout master`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,18 +1,5 @@
 ## Releases
 
-## Preparation
-
-To **prepare the extension for a new version**, you must:
-
-- update and commit the version in `package.json`
-- update and commit the `CHANGELOG.md`
-- tag, push, and merge to the `master` branch on GitHub
-
-## Packaging
-
-To **build a signed extension .xpi**, you must: commit and push to the
-`production` branch (ideally as a merge from `master`) on GitHub.
-
 ### Instructions
 
 1. Update "version" in package.json (and package-lock.json)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,50 +1,55 @@
-## Releases
+# Releases
 
-### Checklist
+## Checklist
 
-* Unfinished work has been triaged and assigned to the appropriate milestone
-* Finished work is verified on `master`
-* Product, Engineering, and PI have signed-off on releasing
+Before a release can be made, the following must be done:
 
-### Instructions
+* All finished work is verified to work as expected and committed to `master`
+* Any unfinished work has been triaged and assigned to the appropriate milestone
+* Product, Engineering, and PI have voiced approval to release (e.g., via Slack team channel)
 
-**NOTE:** These instructions assume:
 
+## Instructions
+
+**NOTE:** these instructions assume:
+
+* All of the [checklist items](#checklist) are complete
 * You are an administrator of the project `lockbox-extension`
-* Your local git repository has a `upstream` remote pointing to `git@github.com:mozilla-lockbox/lockbox-extension.git`
+* Your local git working copy has a remote named `upstream` pointing to `git@github.com:mozilla-lockbox/lockbox-extension.git`
+
+To generate the next release binary:
 
 1. Update "version" in package.json (and package-lock.json)
     - we follow the [semver](http://semver.org/) syntax
-    - Alpha releases will be tagged with "-alpha" (e.g., "0.1.0-alpha")
-    - Beta releases will be tagged with "-beta" (e.g., "0.x.0-beta")
-    - Stable releases will **not** be tagged, and follow smever from the last Beta release (major, minor, and patch)
-2. Update `docs/release-notes.md`
-    - latest release goes to the top, under a second-level header
+    - _Alpha_ releases will be labeled with "-alpha" (e.g., "0.1.0-alpha")
+    - _Beta_ releases will be labeled with "-beta" (e.g., "1.0.0-beta")
+    - _Stable_ releases will **not** be labeled, and follow smever from the last Beta release (e.g., "1.0.0")
+2. Update `docs/release-notes.md`:
+    - latest release is at the top, under a second-level header
     - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"
     - consult with Product Management on wording if needed
-2. Commit and ultimately merge to "master" branch
-3. Merge and push "master" branch to "production" branch
+2. Commit and ultimately merge to `master` branch
+3. Merge the `master` branch into `production` branch and push to GitHub:
     - `git checkout master`
     - `git pull upstream master` (to make sure you have the latest)
     - `git checkout production`
     - `git pull upstream production` (to make sure you have the latest)
     - `git merge master`
     - `git push upstream production`
-    - Jenkins will now build and sign the extension (see "Extension Signing")
-4. Tag the production branch at the version and push the tag
+    - Test Pilot's Jenkins will now build and sign the extension (see ["Extension Signing"](#extension-signing))
+4. Tag the latest commit on `production` branch with an annotated version and push the tag:
     - `git tag -a -m "Release 0.1.0" 0.1.0`
     - `git push upstream 0.1.0`
-    - Travis CI will build and generate a GitHub Release
+    - Travis-CI will build and generate a GitHub Release
 7. Edit the resulting GitHub Release
     - Set the GitHub Release title to match the version
-    - Set the notes to match the `docs/release-notes.md`
-    - Download the `signed-addon.xpi`
-        - `wget -O signed-addon.xpi https://testpilot.firefox.com/files/lockbox@mozilla.com/latest`
-    - Attach it to the release
-8. Announcement sent to the team that all steps are complete (e.g., via Slack team channel)
+    - Set the GitHub Release notes to match the `docs/release-notes.md`
+    - Download the signed add-on: `wget -O signed-addon.xpi https://testpilot.firefox.com/files/lockbox@mozilla.com/latest`
+    - Attach to the GitHub Release the downloaded signed add-on
+8. Send an announcement to the team (e.g., via Slack team channel)
 
 
-### Extension Signing
+## Extension Signing
 
 Learn about the Test Pilot extension deployment and hosting process here:  
 https://github.com/mozilla/testpilot/blob/master/docs/development/hosting.md
@@ -58,4 +63,4 @@ The resulting files deployed are:
 - Updates file for automatic browser extension updates: https://testpilot.firefox.com/files/lockbox@mozilla.com/updates.json
 - Latest version of the signed extension XPI: https://testpilot.firefox.com/files/lockbox@mozilla.com/latest
 
-Join #testpilot-bots in IRC for updates on the status of builds.
+**IMPORTANT** Join the IRC channel **#testpilot-bots** for updates on the status of these builds prior to pushing the `production` branch to GitHub.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,7 +24,7 @@ To generate the next release binary:
     - we follow the [semver](http://semver.org/) syntax
     - _Alpha_ releases will be labeled with "-alpha" (e.g., "0.1.0-alpha")
     - _Beta_ releases will be labeled with "-beta" (e.g., "1.0.0-beta")
-    - _Stable_ releases will **not** be labeled, and follow smever from the last Beta release (e.g., "1.0.0")
+    - _Stable_ releases will **not** be labeled, and follow semver from the last Beta release (e.g., "1.0.0")
 2. Update `docs/release-notes.md`:
     - latest release is at the top, under a second-level header
     - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,31 +2,36 @@
 
 ### Instructions
 
+**NOTE:** These instructions assume:
+
+* You are an administrator of the project `lockbox-extension`
+* Your local git repository has a `upstream` remote pointing to `git@github.com:mozilla-lockbox/lockbox-extension.git`
+
 1. Update "version" in package.json (and package-lock.json)
     - we follow the [semver](http://semver.org/) syntax
     - Alpha releases will be tagged with "-alpha" (e.g., "0.1.0-alpha")
     - Beta releases will be tagged with "-beta" (e.g., "0.x.0-beta")
     - Stable releases will **not** be tagged, and follow smever from the last Beta release (major, minor, and patch)
-2. Update "release-notes.md"
+2. Update `docs/release-notes.md`
     - latest release goes to the top, under a second-level header
     - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"
     - consult with Product Management
 2. Commit and ultimately merge to "master" branch
 3. Merge and push "master" branch to "production" branch
     - `git checkout master`
-    - `git pull` (to make sure you have the latest)
+    - `git pull upstream master` (to make sure you have the latest)
     - `git checkout production`
-    - `git pull` (to make sure you have the latest)
+    - `git pull upstream production` (to make sure you have the latest)
     - `git merge master`
-    - `git push`
+    - `git push upstream production`
     - Jenkins will now build and sign the extension (see "Extension Signing")
-4. Tag the production branch at the version
-    - `git tag 0.1.0`
-    - `git push --tags`
+4. Tag the production branch at the version and push the tag
+    - `git tag -a -m "Release 0.1.0" 0.1.0`
+    - `git push upstream 0.1.0`
     - Travis CI will build and generate a GitHub Release
 7. Edit the resulting GitHub Release
     - Set the GitHub Release title to match the version
-    - Set the notes to match the CHANGELOG
+    - Set the notes to match the `docs/release-notes.md`
     - Download the `signed-addon.xpi` and attach it to the release
 
 ### Extension Signing

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,6 +3,10 @@
 ### Instructions
 
 1. Update "version" in package.json (and package-lock.json)
+  - we follow the [semver](http://semver.org/) convention
+  - versions "0.1.0" to "1.0.0" is reserved for the internal Alpha
+  - version "1.0.0" is reserved for a public Beta
+  - major, minor, and patch releases will follow semver from there
 2. Update "CHANGELOG.md" using `conventional-changelog`
 2. Commit and ultimately merge to "master" branch
 3. Merge and push "master" branch to "production" branch


### PR DESCRIPTION
Resolves #195 

@linuxwolf @jimporter here are detailed instructions (just performed at 0.1.0-pre3, sans CHANGELOG) to publish a new version with a signed extension on Test Pilot and GitHub.

I showed @m8ttyB the actual Jenkins build/sign pipeline. The code is in a private repo and shared with all Test Pilot extensions, Jenkins/CloudBees with resulting output is behind a proxy requiring CloudOps access. Please let me know if it'd be helpful to walk through and demonstrate any of that. But you should be able to see the steps and results (building, signed, deployed) in IRC at `#testpilot-bots`.

I know this has already been reviewed and demonstrated, but do you have any other concerns? 

Anything in this process you'd like me to flesh out more?

Any questions? 😄 

Fixes #26