### PR TITLE
(WIP) Alpha UI updates to get closer to mockups

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,5 +32,6 @@ module.exports = {
     "comma-dangle": ["error", "always-multiline"],
     "curly": "error",
     "no-console": "warn",
+    "semi": "error",
   },
-}
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,5 +46,5 @@ module.exports = function(config) {
     autoWatch: true,
     singleRun: true,
     concurrency: Infinity,
-  })
+  });
 };

--- a/src/webextension/firstrun/components/master-password-setup.js
+++ b/src/webextension/firstrun/components/master-password-setup.js
@@ -94,7 +94,7 @@ export default class MasterPasswordSetup extends React.Component {
         </label>
         <div className={styles.error}>{error}</div>
         <Localized id="master-password-setup-submit">
-          <Button className="default" type="submit">iNIt</Button>
+          <Button theme="primary" type="submit">iNIt</Button>
         </Localized>
       </form>
     );

--- a/src/webextension/firstrun/components/master-password-setup.js
+++ b/src/webextension/firstrun/components/master-password-setup.js
@@ -51,7 +51,7 @@ export default class MasterPasswordSetup extends React.Component {
         await browser.runtime.sendMessage({
           type: "close_view",
           name: "firstrun",
-        })
+        });
       } catch (err) {
         console.log(`initialize failed: ${err.message}`);
         // TODO: Localize this!

--- a/src/webextension/firstrun/components/master-password-setup.js
+++ b/src/webextension/firstrun/components/master-password-setup.js
@@ -17,6 +17,10 @@ export default class MasterPasswordSetup extends React.Component {
     this.state = {};
   }
 
+  componentDidMount() {
+    this._firstField.focus();
+  }
+
   handleChange(event) {
     this.setState({
       [event.target.name]: event.target.value,
@@ -63,15 +67,11 @@ export default class MasterPasswordSetup extends React.Component {
   }
 
   render() {
-    const controlledProps = (name) => {
-      return {
-        name,
-        value: this.state[name],
-        onChange: (e) => this.handleChange(e),
-      };
-    };
-
     const { error = "\u00a0" } = this.state;
+    const controlledProps = (name) => {
+      return {name, value: this.state[name],
+              onChange: (e) => this.handleChange(e)};
+    };
 
     return (
       <form className={styles.masterPasswordSetup}
@@ -83,7 +83,8 @@ export default class MasterPasswordSetup extends React.Component {
           <Localized id="master-password-setup-password">
             <div>pASSWORd</div>
           </Localized>
-          <PasswordInput {...controlledProps("password")}/>
+          <PasswordInput {...controlledProps("password")}
+                         ref={(element) => this._firstField = element}/>
         </label>
         <label>
           <Localized id="master-password-setup-confirm">
@@ -93,7 +94,7 @@ export default class MasterPasswordSetup extends React.Component {
         </label>
         <div className={styles.error}>{error}</div>
         <Localized id="master-password-setup-submit">
-          <Button type="submit">iNIt</Button>
+          <Button className="default" type="submit">iNIt</Button>
         </Localized>
       </form>
     );

--- a/src/webextension/l10n.js
+++ b/src/webextension/l10n.js
@@ -52,7 +52,7 @@ async function createMessagesGenerator(baseDir, currentLocales, bundles) {
       }
       yield cx;
     }
-  }
+  };
 }
 
 export default class AppLocalizationProvider extends Component {

--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -38,6 +38,10 @@ homepage-over-50-passwords =
   
   You've added { $count } entries. Wow, I'm really impressed!
 
+item-details-heading-view = Entry Details
+item-details-heading-new = Create a New Entry
+item-details-heading-edit = Edit Entry
+
 item-details-title = Entry Name
 item-details-origin = Website Address
 item-details-username = Username
@@ -51,7 +55,8 @@ item-details-notes = Notes
 item-details-edit = Edit Entry
 item-details-delete = Delete Entry
 
-item-details-save = Save Entry
+item-details-save-new = Save Entry
+item-details-save-existing = Save Changes
 item-details-cancel = Cancel
 
 [[dialogs]]

--- a/src/webextension/manage/components/app.css
+++ b/src/webextension/manage/components/app.css
@@ -14,11 +14,15 @@ body > main,
   height: 100%;
   grid-template-columns: 1fr 5fr;
   grid-template-rows: auto 1fr;
-  grid-column-gap: 1em;
+}
+
+.side-toolbar,
+.main-toolbar {
+  background-color: #f9f9f9;
+  border-bottom: 1px solid #d6d6d6;
 }
 
 .side-toolbar {
-  background-color: #f9f9fa;
   padding-inline-end: 0;
 }
 
@@ -30,11 +34,13 @@ body > main,
   grid-column: 1;
   min-width: 0;
   min-height: 0;
-  background-color: #f9f9fa;
+  background-color: #e6e6e6;
+  border-right: 1px solid #e1e1e1;
   display: grid;
   grid-template-rows: auto 1fr auto;
 }
 
 .app-main > article {
   grid-column: 2;
+  background-color: #f9f9f9;
 }

--- a/src/webextension/manage/components/app.js
+++ b/src/webextension/manage/components/app.js
@@ -26,8 +26,8 @@ export default function App() {
           <AddItem/>
         </Toolbar>
         <Toolbar className={styles.mainToolbar}>
-          <GoHome/>
           <ToolbarSpace/>
+          <GoHome/>
           <SendFeedback/>
         </Toolbar>
         <aside>

--- a/src/webextension/manage/components/edit-item-details.js
+++ b/src/webextension/manage/components/edit-item-details.js
@@ -111,10 +111,11 @@ export default class EditItemDetails extends React.Component {
         </label>
         <Toolbar className={styles.buttons}>
           <Localized id={`item-details-save-${newItem ? "new" : "existing"}`}>
-            <Button className="default" type="submit">sAVe</Button>
+            <Button type="submit" theme="primary">sAVe</Button>
           </Localized>
           <Localized id="item-details-cancel">
-            <Button type="button" onClick={(e) => onCancel(this._changed)}>
+            <Button type="button" theme="minimal"
+                    onClick={(e) => onCancel(this._changed)}>
               cANCEl
             </Button>
           </Localized>

--- a/src/webextension/manage/components/edit-item-details.js
+++ b/src/webextension/manage/components/edit-item-details.js
@@ -21,6 +21,7 @@ import styles from "./item-details.css";
 export default class EditItemDetails extends React.Component {
   static get propTypes() {
     return {
+      newItem: PropTypes.bool,
       fields: PropTypes.shape({
         title: PropTypes.string.isRequired,
         origin: PropTypes.string.isRequired,
@@ -35,6 +36,7 @@ export default class EditItemDetails extends React.Component {
 
   static get defaultProps() {
     return {
+      newItem: false,
       fields: {
         title: "",
         origin: "",
@@ -61,7 +63,7 @@ export default class EditItemDetails extends React.Component {
   }
 
   render() {
-    const {onSave, onCancel} = this.props;
+    const {newItem, onSave, onCancel} = this.props;
     const controlledProps = (name) => {
       return {name, value: this.state[name],
               onChange: (e) => this.handleChange(e)};
@@ -73,6 +75,9 @@ export default class EditItemDetails extends React.Component {
               e.preventDefault();
               onSave(this.state);
             }}>
+        <Localized id={`item-details-heading-${newItem ? "new" : "edit"}`}>
+          <h1>eDIt iTEm</h1>
+        </Localized>
         <label>
           <Localized id="item-details-title">
             <LabelText>tITLe</LabelText>
@@ -105,7 +110,7 @@ export default class EditItemDetails extends React.Component {
           <TextArea {...controlledProps("notes")}/>
         </label>
         <Toolbar className={styles.buttons}>
-          <Localized id="item-details-save">
+          <Localized id={`item-details-save-${newItem ? "new" : "existing"}`}>
             <Button className="default" type="submit">sAVe</Button>
           </Localized>
           <Localized id="item-details-cancel">

--- a/src/webextension/manage/components/edit-item-details.js
+++ b/src/webextension/manage/components/edit-item-details.js
@@ -10,7 +10,8 @@ import Button from "../../widgets/button";
 import Input from "../../widgets/input";
 import PasswordInput from "../../widgets/password-input";
 import TextArea from "../../widgets/text-area";
-import { Text } from "./item-details.js";
+import Toolbar from "../../widgets/toolbar";
+import { LabelText } from "./item-details.js";
 
 import styles from "./item-details.css";
 
@@ -74,45 +75,45 @@ export default class EditItemDetails extends React.Component {
             }}>
         <label>
           <Localized id="item-details-title">
-            <Text>tITLe</Text>
+            <LabelText>tITLe</LabelText>
           </Localized>
           <Input type="text" {...controlledProps("title")}
                  ref={(element) => this._firstField = element}/>
         </label>
         <label>
           <Localized id="item-details-origin">
-            <Text>oRIGIn</Text>
+            <LabelText>oRIGIn</LabelText>
           </Localized>
           <Input type="text" {...controlledProps("origin")}/>
         </label>
         <label>
           <Localized id="item-details-username">
-            <Text>uSERNAMe</Text>
+            <LabelText>uSERNAMe</LabelText>
           </Localized>
           <Input type="text" {...controlledProps("username")}/>
         </label>
         <label>
           <Localized id="item-details-password">
-            <Text>pASSWORd</Text>
+            <LabelText>pASSWORd</LabelText>
           </Localized>
           <PasswordInput {...controlledProps("password")}/>
         </label>
         <label>
           <Localized id="item-details-notes">
-            <Text>nOTEs</Text>
+            <LabelText>nOTEs</LabelText>
           </Localized>
           <TextArea {...controlledProps("notes")}/>
         </label>
-        <div className={styles.buttons}>
+        <Toolbar className={styles.buttons}>
           <Localized id="item-details-save">
-            <Button type="submit">sAVe</Button>
+            <Button className="default" type="submit">sAVe</Button>
           </Localized>
           <Localized id="item-details-cancel">
             <Button type="button" onClick={(e) => onCancel(this._changed)}>
               cANCEl
             </Button>
           </Localized>
-        </div>
+        </Toolbar>
       </form>
     );
   }

--- a/src/webextension/manage/components/item-details.css
+++ b/src/webextension/manage/components/item-details.css
@@ -4,10 +4,10 @@
 
 .item-details {
   display: grid;
-  grid-template-columns: max-content minmax(225px, max-content);
+  grid-template-columns: minmax(225px, max-content);
   grid-column-gap: 1em;
-  grid-row-gap: 6px;
-  margin: 1em;
+  grid-row-gap: 3px;
+  margin: 2em;
 }
 
 .item-details > label,
@@ -15,31 +15,20 @@
   display: contents;
 }
 
-.item-details > label > *:first-child,
-.item-details > .field > *:first-child {
-  grid-column: 1;
-}
-
-.item-details > .buttons {
-  grid-column: 2;
-}
-
-.item-details .text {
-  /* This lines up our labels with the text in <input> elements. */
-  margin-top: 3.5px;
-  height: 20.5px;
-}
-
-.item-details > .field > .text + * {
-  margin-inline-start: 7px;
-}
-
 .item-details textarea {
   resize: none;
 }
 
-.buttons > button + button {
-  margin-inline-start: 1ch;
+.label-text {
+  margin-inline-start: 7px;
+  margin-top: 0.5em;
+}
+
+.field-text {
+  /* This lines up our labels with the text in <input> elements. */
+  margin-top: 3.5px;
+  height: 20.5px;
+  margin-inline-start: 7px;
 }
 
 .inline-button {
@@ -48,4 +37,10 @@
 
 .inline-button > *:first-child {
   flex: 1;
+}
+
+.buttons {
+  border-top: 1px solid #d6d6d6;
+  margin-top: 1em;
+  padding: 1em 0;
 }

--- a/src/webextension/manage/components/item-details.css
+++ b/src/webextension/manage/components/item-details.css
@@ -11,6 +11,13 @@
   max-width: 320px;
 }
 
+.item-details > h1 {
+  margin-top: 7px;
+  margin-inline-start: 7px;
+  font-weight: normal;
+  font-size: 1.5em;
+}
+
 .item-details > label,
 .item-details > .field {
   display: contents;
@@ -23,6 +30,7 @@
 .label-text {
   margin-inline-start: 7px;
   margin-top: 0.5em;
+  color: #626262;
 }
 
 .field-text {

--- a/src/webextension/manage/components/item-details.css
+++ b/src/webextension/manage/components/item-details.css
@@ -4,10 +4,11 @@
 
 .item-details {
   display: grid;
-  grid-template-columns: minmax(225px, max-content);
+  grid-template-columns: minmax(200px, 1fr);
   grid-column-gap: 1em;
   grid-row-gap: 3px;
   margin: 2em;
+  max-width: 320px;
 }
 
 .item-details > label,
@@ -27,7 +28,7 @@
 .field-text {
   /* This lines up our labels with the text in <input> elements. */
   margin-top: 3.5px;
-  height: 20.5px;
+  min-height: 20.5px;
   margin-inline-start: 7px;
 }
 
@@ -37,6 +38,8 @@
 
 .inline-button > *:first-child {
   flex: 1;
+  overflow: hidden;
+  overflow-wrap: break-word;
 }
 
 .buttons {

--- a/src/webextension/manage/components/item-details.js
+++ b/src/webextension/manage/components/item-details.js
@@ -8,25 +8,23 @@ import React from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 
 import Button from "../../widgets/button";
+import Toolbar from "../../widgets/toolbar";
 
 import styles from "./item-details.css";
 
 const PASSWORD_DOT = "\u25cf";
 
-export function Text({className, ...props}) {
-  const finalClassName = `${styles.text} ${className}`.trimRight();
+export function LabelText(props) {
   return (
-    <span className={finalClassName} {...props}/>
+    <span className={styles.labelText} {...props}/>
   );
 }
 
-Text.propTypes = {
-  className: PropTypes.string,
-};
-
-Text.defaultProps = {
-  className: "",
-};
+export function FieldText(props) {
+  return (
+    <span className={styles.fieldText} {...props}/>
+  );
+}
 
 function CopyToClipboardButton({text, ...props}) {
   return (
@@ -48,22 +46,22 @@ export default function ItemDetails({fields, onEdit, onDelete}) {
     <div className={styles.itemDetails}>
       <div className={styles.field}>
         <Localized id="item-details-title">
-          <Text>tITLe</Text>
+          <LabelText>tITLe</LabelText>
         </Localized>
-        <Text data-name="title">{fields.title}</Text>
+        <FieldText data-name="title">{fields.title}</FieldText>
       </div>
       <div className={styles.field}>
         <Localized id="item-details-origin">
-          <Text>oRIGIn</Text>
+          <LabelText>oRIGIn</LabelText>
         </Localized>
-        <Text data-name="origin">{fields.origin}</Text>
+        <FieldText data-name="origin">{fields.origin}</FieldText>
       </div>
       <div className={styles.field}>
         <Localized id="item-details-username">
-          <Text>uSERNAMe</Text>
+          <LabelText>uSERNAMe</LabelText>
         </Localized>
         <div className={styles.inlineButton}>
-          <Text data-name="username">{fields.username}</Text>
+          <FieldText data-name="username">{fields.username}</FieldText>
           <Localized id="item-details-copy-username">
             <CopyToClipboardButton text={fields.username}>
               cOPy
@@ -73,12 +71,12 @@ export default function ItemDetails({fields, onEdit, onDelete}) {
       </div>
       <div className={styles.field}>
         <Localized id="item-details-password">
-          <Text>pASSWORd</Text>
+          <LabelText>pASSWORd</LabelText>
         </Localized>
         <div className={styles.inlineButton}>
-        <Text data-name="password">
-          {PASSWORD_DOT.repeat(fields.password.length)}
-        </Text>
+          <FieldText data-name="password">
+            {PASSWORD_DOT.repeat(fields.password.length)}
+          </FieldText>
           <Localized id="item-details-copy-password">
             <CopyToClipboardButton text={fields.password}>
               cOPy
@@ -88,18 +86,18 @@ export default function ItemDetails({fields, onEdit, onDelete}) {
       </div>
       <div className={styles.field}>
         <Localized id="item-details-notes">
-          <Text>nOTEs</Text>
+          <LabelText>nOTEs</LabelText>
         </Localized>
-        <Text data-name="notes">{fields.notes}</Text>
+        <FieldText data-name="notes">{fields.notes}</FieldText>
       </div>
-      <div className={styles.buttons}>
+      <Toolbar className={styles.buttons}>
         <Localized id="item-details-edit">
           <Button onClick={() => onEdit()}>eDIt</Button>
         </Localized>
         <Localized id="item-details-delete">
           <Button onClick={() => onDelete()}>dELETe</Button>
         </Localized>
-      </div>
+      </Toolbar>
     </div>
   );
 }

--- a/src/webextension/manage/components/item-details.js
+++ b/src/webextension/manage/components/item-details.js
@@ -98,7 +98,7 @@ export default function ItemDetails({fields, onEdit, onDelete}) {
           <Button onClick={() => onEdit()}>eDIt</Button>
         </Localized>
         <Localized id="item-details-delete">
-          <Button onClick={() => onDelete()}>dELETe</Button>
+          <Button theme="minimal" onClick={() => onDelete()}>dELETe</Button>
         </Localized>
       </Toolbar>
     </div>

--- a/src/webextension/manage/components/item-details.js
+++ b/src/webextension/manage/components/item-details.js
@@ -44,6 +44,9 @@ CopyToClipboardButton.propTypes = {
 export default function ItemDetails({fields, onEdit, onDelete}) {
   return (
     <div className={styles.itemDetails}>
+      <Localized id={"item-details-heading-view"}>
+        <h1>eDIt iTEm</h1>
+      </Localized>
       <div className={styles.field}>
         <Localized id="item-details-title">
           <LabelText>tITLe</LabelText>

--- a/src/webextension/manage/components/item-list.css
+++ b/src/webextension/manage/components/item-list.css
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.item:nth-child(2n+1) {
+  background-color: #f1f1f1;
+}
+
+.item:nth-child(2n) {
+  background-color: #f9f9f9;
+}

--- a/src/webextension/manage/components/item-list.js
+++ b/src/webextension/manage/components/item-list.js
@@ -8,9 +8,11 @@ import React from "react";
 import ItemSummary from "./item-summary";
 import ScrollingList from "../../widgets/scrolling-list";
 
+import styles from "./item-list.css";
+
 export default function ItemList({items, selected, onItemSelected}) {
   return (
-    <ScrollingList data={items} selected={selected}
+    <ScrollingList itemClassName={styles.item} data={items} selected={selected}
                    onItemSelected={onItemSelected}>
       {({title, username}) => {
         return (

--- a/src/webextension/manage/components/send-feedback.js
+++ b/src/webextension/manage/components/send-feedback.js
@@ -18,7 +18,7 @@ export default function SendFeedback() {
 
   return (
     <Localized id="toolbar-send-feedback">
-      <Button onClick={doClick}>
+      <Button theme="minimal" onClick={doClick}>
         fEEDBACk
       </Button>
     </Localized>

--- a/src/webextension/manage/containers/add-item.js
+++ b/src/webextension/manage/containers/add-item.js
@@ -19,7 +19,7 @@ function AddItem({dispatch}) {
 
   return (
     <Localized id="toolbar-add-item">
-      <Button onClick={doClick}>
+      <Button className="default" onClick={doClick}>
         aDd iTEm
       </Button>
     </Localized>

--- a/src/webextension/manage/containers/add-item.js
+++ b/src/webextension/manage/containers/add-item.js
@@ -19,7 +19,7 @@ function AddItem({dispatch}) {
 
   return (
     <Localized id="toolbar-add-item">
-      <Button className="default" onClick={doClick}>
+      <Button theme="primary" onClick={doClick}>
         aDd iTEm
       </Button>
     </Localized>

--- a/src/webextension/manage/containers/current-selection.js
+++ b/src/webextension/manage/containers/current-selection.js
@@ -39,6 +39,7 @@ function flattenItem(item) {
 
 const ConnectedEditItemDetails = connect(
   (state, ownProps) => ({
+    newItem: !ownProps.item,
     fields: ownProps.item ? flattenItem(ownProps.item) : undefined,
   }),
   (dispatch, ownProps) => {

--- a/src/webextension/manage/containers/go-home.js
+++ b/src/webextension/manage/containers/go-home.js
@@ -13,7 +13,7 @@ import { selectItem } from "../actions";
 function GoHome({dispatch}) {
   return (
     <Localized id="toolbar-go-home">
-      <Button onClick={() => { dispatch(selectItem(null)); }}>
+      <Button theme="minimal" onClick={() => { dispatch(selectItem(null)); }}>
         hOMe
       </Button>
     </Localized>

--- a/src/webextension/manage/containers/item-count.css
+++ b/src/webextension/manage/containers/item-count.css
@@ -3,5 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .item-count {
+  font-size: 1.25em;
   white-space: nowrap;
 }

--- a/src/webextension/widgets/button-stack.css
+++ b/src/webextension/widgets/button-stack.css
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* This should work like <xul:deck>, but it has some significant limitations
+   (mainly that every element should be the same height). Perhaps there's a
+   better way to do all this... */
+
+.stack {
+  display: flex;
+  flex-direction: column;
+}
+
+.stack-item {
+  height: 0;
+  visibility: hidden;
+}
+
+.stack-item[data-selected] {
+  visibility: visible;
+}
+
+.stack-item > * {
+  width: 100%;
+}

--- a/src/webextension/widgets/button-stack.js
+++ b/src/webextension/widgets/button-stack.js
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PropTypes from "prop-types";
+import React from "react";
+
+import styles from "./button-stack.css";
+
+export default class ButtonStack extends React.Component {
+  static get propTypes() {
+    return {
+      children: PropTypes.node,
+    };
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selectedIndex: 0,
+    };
+  }
+
+  get selectedIndex() {
+    return this.state.selectedIndex;
+  }
+
+  set selectedIndex(value) {
+    this.setState({selectedIndex: value});
+    return value;
+  }
+
+  render() {
+    const { children } = this.props;
+    const { selectedIndex } = this.state;
+
+    return (
+      <div className={styles.stack}>
+        {React.Children.map(children, (child, i) => {
+          const props = {};
+          if (i === selectedIndex) {
+            props["data-selected"] = true;
+          }
+
+          return (
+            <span className={styles.stackItem} key={i} {...props}>
+              {child}
+            </span>
+          );
+        })}
+      </div>
+    );
+  }
+}

--- a/src/webextension/widgets/button.css
+++ b/src/webextension/widgets/button.css
@@ -6,4 +6,5 @@ button.button {
   white-space: nowrap;
   /* Override the margin-bottom from browser-style. */
   margin-bottom: 0;
+  text-align: center;
 }

--- a/src/webextension/widgets/button.css
+++ b/src/webextension/widgets/button.css
@@ -8,3 +8,8 @@ button.button {
   margin-bottom: 0;
   text-align: center;
 }
+
+button.minimal {
+  /* Override the browser-style borders. */
+  border: 0 !important;
+}

--- a/src/webextension/widgets/button.js
+++ b/src/webextension/widgets/button.js
@@ -7,15 +7,23 @@ import React from "react";
 
 import styles from "./button.css";
 
+const THEME_CLASS_NAME = {
+  primary: "browser-style default",
+  normal: "browser-style",
+  minimal: `browser-style ${styles.minimal}`,
+};
+
 export default class Button extends React.Component {
   static get propTypes() {
     return {
+      theme: PropTypes.oneOf(["primary", "normal", "minimal"]),
       className: PropTypes.string,
     };
   }
 
   static get defaultProps() {
     return {
+      theme: "normal",
       className: "",
     };
   }
@@ -25,9 +33,11 @@ export default class Button extends React.Component {
   }
 
   render() {
-    const {className, ...props} = this.props;
-    const finalClassName = `browser-style ${styles.button} ${className}`
-                           .trimRight();
+    const {className, theme, ...props} = this.props;
+    const finalClassName = (
+      `${THEME_CLASS_NAME[theme]} ${styles.button} ${className}`
+    ).trimRight();
+
     return (
       <button className={finalClassName} {...props}
               ref={(element) => this.buttonElement = element}/>

--- a/src/webextension/widgets/dialog-box.js
+++ b/src/webextension/widgets/dialog-box.js
@@ -21,7 +21,7 @@ export default class DialogBox extends React.Component {
       <section className={styles.modalDialog}>
         <div>{text}</div>
         <menu>
-          <Button onClick={() => { onClickPrimary(); }}
+          <Button theme="primary" onClick={() => { onClickPrimary(); }}
                   ref={(element) => this._primaryButton = element}>
             {primaryButtonLabel}
           </Button>

--- a/src/webextension/widgets/password-input.css
+++ b/src/webextension/widgets/password-input.css
@@ -16,7 +16,8 @@
   width: 100%;
 }
 
-.password-input > button {
+.password-input button {
+  text-align: center;
   margin-inline-start: -1px;
   /* Override the margin-bottom from browser-style. */
   margin-bottom: 0;

--- a/src/webextension/widgets/password-input.js
+++ b/src/webextension/widgets/password-input.js
@@ -6,6 +6,8 @@ import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
+import ButtonStack from "./button-stack.js";
+
 import styles from "./password-input.css";
 
 export default class PasswordInput extends React.Component {
@@ -24,8 +26,14 @@ export default class PasswordInput extends React.Component {
     };
   }
 
-  toggleShowPassword() {
-    this.setState({showPassword: !this.state.showPassword});
+  showPassword(show) {
+    if (show) {
+      this.stackElement.selectedIndex = 1;
+      this.setState({showPassword: true});
+    } else {
+      this.stackElement.selectedIndex = 0;
+      this.setState({showPassword: false});
+    }
   }
 
   focus() {
@@ -40,11 +48,16 @@ export default class PasswordInput extends React.Component {
                  {...this.props}
                  ref={(element) => this.inputElement = element}/>
         </span>
-        <Localized id={this.state.showPassword ? "password-input-hide" :
-                       "password-input-show"}>
-          <button type="button" className="browser-style"
-                  onClick={() => this.toggleShowPassword()}>sHOw/hIDe</button>
-        </Localized>
+        <ButtonStack ref={(element) => this.stackElement = element}>
+          <Localized id="password-input-show">
+            <button type="button" className="browser-style"
+                    onClick={() => this.showPassword(true)}>sHOw</button>
+          </Localized>
+          <Localized id="password-input-hide">
+            <button type="button" className="browser-style"
+                    onClick={() => this.showPassword(false)}>hIDe</button>
+          </Localized>
+        </ButtonStack>
       </div>
     );
   }

--- a/src/webextension/widgets/scrolling-list.js
+++ b/src/webextension/widgets/scrolling-list.js
@@ -10,6 +10,8 @@ import styles from "./scrolling-list.css";
 export default class ScrollingList extends React.Component {
   static get propTypes() {
     return {
+      className: PropTypes.string,
+      itemClassName: PropTypes.string,
       children: PropTypes.func.isRequired,
       data: PropTypes.arrayOf(
         PropTypes.shape({
@@ -24,6 +26,8 @@ export default class ScrollingList extends React.Component {
 
   static get defaultProps() {
     return {
+      className: "",
+      itemClassName: "",
       tabIndex: "0",
       selected: null,
     };
@@ -89,14 +93,19 @@ export default class ScrollingList extends React.Component {
   }
 
   render() {
-    const {children, data, tabIndex, selected, onItemSelected} = this.props;
+    const { className, itemClassName, children, data, tabIndex, selected,
+            onItemSelected } = this.props;
+    const finalClassName = `${styles.scrollingList} ${className}`
+                           .trimRight();
+
     return (
-      <ul tabIndex={tabIndex} className={styles.scrollingList}
+      <ul tabIndex={tabIndex} className={finalClassName}
           ref={(element) => this._rootElement = element}
           onKeyDown={(e) => this.handleKeyDown(e)}>
         {data.map((item) => {
           let props = {
             onMouseDown: () => onItemSelected(item.id),
+            className: itemClassName,
           };
           if (item.id === selected) {
             Object.assign(props, {

--- a/test/manage/actions-test.js
+++ b/test/manage/actions-test.js
@@ -255,7 +255,7 @@ describe("manage > actions", () => {
   });
 
   it("hideModal() dispatched", () => {
-    store.dispatch(actions.hideModal())
+    store.dispatch(actions.hideModal());
     expect(store.getActions()).to.deep.equal([
       { type: actions.HIDE_MODAL },
     ]);

--- a/test/manage/components/edit-item-details-test.js
+++ b/test/manage/components/edit-item-details-test.js
@@ -51,7 +51,7 @@ describe("manage > components > <EditItemDetails/>", () => {
   describe("new item", () => {
     beforeEach(() => {
       wrapper = mountWithL10n(
-        <EditItemDetails onSave={onSave} onCancel={onCancel}/>
+        <EditItemDetails newItem={true} onSave={onSave} onCancel={onCancel}/>
       );
     });
 
@@ -64,7 +64,7 @@ describe("manage > components > <EditItemDetails/>", () => {
     });
 
     it("onSave called", () => {
-      wrapper.findWhere((x) => x.prop("id") === "item-details-save")
+      wrapper.findWhere((x) => x.prop("id") === "item-details-save-new")
              .find("button").simulate("submit");
       expect(onSave).to.have.been.calledWith(blankFields);
     });
@@ -75,7 +75,7 @@ describe("manage > components > <EditItemDetails/>", () => {
           return typeof x.type() === "string";
         }), updatedFields[i]);
       }
-      wrapper.findWhere((x) => x.prop("id") === "item-details-save")
+      wrapper.findWhere((x) => x.prop("id") === "item-details-save-new")
              .find("button").simulate("submit");
 
       expect(onSave).to.have.been.calledWith(updatedFields);
@@ -105,7 +105,7 @@ describe("manage > components > <EditItemDetails/>", () => {
     });
 
     it("onSave called", () => {
-      wrapper.findWhere((x) => x.prop("id") === "item-details-save")
+      wrapper.findWhere((x) => x.prop("id") === "item-details-save-existing")
              .find("button").simulate("submit");
       expect(onSave).to.have.been.calledWith(originalFields);
     });
@@ -116,7 +116,7 @@ describe("manage > components > <EditItemDetails/>", () => {
           return typeof x.type() === "string";
         }), updatedFields[i]);
       }
-      wrapper.findWhere((x) => x.prop("id") === "item-details-save")
+      wrapper.findWhere((x) => x.prop("id") === "item-details-save-existing")
              .find("button").simulate("submit");
 
       expect(onSave).to.have.been.calledWith(updatedFields);

--- a/test/manage/containers/current-selection-test.js
+++ b/test/manage/containers/current-selection-test.js
@@ -129,7 +129,7 @@ describe("manage > containers > <CurrentSelection/>", () => {
     });
 
     it("addItem() dispatched", () => {
-      wrapper.findWhere((x) => x.prop("id") === "item-details-save")
+      wrapper.findWhere((x) => x.prop("id") === "item-details-save-new")
              .find("button").simulate("submit");
       expect(store.getActions()[0]).to.deep.include({
         type: actions.ADD_ITEM_STARTING,
@@ -200,7 +200,7 @@ describe("manage > containers > <CurrentSelection/>", () => {
     });
 
     it("updateItem() dispatched", () => {
-      wrapper.findWhere((x) => x.prop("id") === "item-details-save")
+      wrapper.findWhere((x) => x.prop("id") === "item-details-save-existing")
              .find("button").simulate("submit");
       expect(store.getActions()[0]).to.deep.include({
         type: actions.UPDATE_ITEM_STARTING,

--- a/test/widgets/button-stack-test.js
+++ b/test/widgets/button-stack-test.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require("babel-polyfill");
+
+import chai, { expect } from "chai";
+import chaiEnzyme from "chai-enzyme";
+import { mount } from "enzyme";
+import React from "react";
+import sinon from "sinon";
+
+chai.use(chaiEnzyme);
+
+import ButtonStack from "src/webextension/widgets/button-stack";
+
+describe("widgets > <ButtonStack/>", () => {
+  beforeEach(() => {
+    sinon.spy(ButtonStack.prototype, "render");
+  });
+
+  afterEach(() => {
+    ButtonStack.prototype.render.restore();
+  });
+
+  it("render stack", () => {
+    const wrapper = mount(
+      <ButtonStack>
+        <button>click me</button>
+      </ButtonStack>
+    );
+    expect(wrapper.find("button")).to.have.text("click me");
+  });
+
+  it("select child", async() => {
+    const wrapper = mount(
+      <ButtonStack>
+        <button>click me</button>
+        <button>click me too</button>
+      </ButtonStack>
+    );
+
+    expect(wrapper.instance().selectedIndex).to.equal(0);
+    expect(wrapper.find("span").at(0)).to.have.prop("data-selected");
+    expect(wrapper.find("span").at(1)).to.not.have.prop("data-selected");
+
+    wrapper.instance().selectedIndex = 1;
+    wrapper.update();
+
+    expect(wrapper.instance().selectedIndex).to.equal(1);
+    expect(wrapper.find("span").at(0)).to.not.have.prop("data-selected");
+    expect(wrapper.find("span").at(1)).to.have.prop("data-selected");
+  });
+});

--- a/test/widgets/password-input-test.js
+++ b/test/widgets/password-input-test.js
@@ -27,10 +27,10 @@ describe("widgets > <PasswordInput/>", () => {
     );
     expect(wrapper.find("input")).to.have.prop("type", "password");
 
-    wrapper.find("button").simulate("click");
+    wrapper.find("button").at(0).simulate("click");
     expect(wrapper.find("input")).to.have.prop("type", "text");
 
-    wrapper.find("button").simulate("click");
+    wrapper.find("button").at(1).simulate("click");
     expect(wrapper.find("input")).to.have.prop("type", "password");
   });
 

--- a/test/widgets/scrolling-list-test.js
+++ b/test/widgets/scrolling-list-test.js
@@ -25,6 +25,21 @@ describe("widgets > <ScrollingList/>", () => {
     onItemSelected = sinon.spy();
   });
 
+  it("merge classNames", () => {
+    wrapper = mount(
+      <ScrollingList className="foo" data={[]} onItemSelected={onItemSelected}>
+        {({item, ...props}) => {
+          return (
+            <li {...props}>{item.name}</li>
+          );
+        }}
+      </ScrollingList>
+    );
+    expect(wrapper.find("ul").prop("className")).to.match(
+      /^\S+ foo$/
+    );
+  });
+
   describe("empty list", () => {
     beforeEach(() => {
       wrapper = mount(


### PR DESCRIPTION
Fixes #138 
Fixes #179 (side-effect of shared code)
Fixes #190 

Quick start at a branch to get closer to @changecourse mockups:

https://mozilla.invisionapp.com/share/5JDP20NYB#/screens/256782990

<img width="1233" alt="screen shot 2017-10-11 at 8 24 21 pm" src="https://user-images.githubusercontent.com/49511/31476177-595046ba-aec2-11e7-8c70-2fe8162b20cf.png">

Where it's at right now:

<img width="719" alt="screen shot 2017-10-11 at 8 21 38 pm" src="https://user-images.githubusercontent.com/49511/31476181-5eadbe94-aec2-11e7-9268-856b16c1e50f.png">

Prioritized things to do before Alpha based on discussion with @changecourse:

- [x] update the firstrun boxes to borrow a little bit of FxA styles
- [x] stack label/input on views 
  - started but not great, needs better spacing
- [ ] add view/edit titles?
- [ ] change secondary buttons to links (save vs delete)
  - started but needs more spacing. not sure if Text is the right item to use
- [x] update the header bar weight/style to get more breathing room and visibility
- [x] placeholder for empty list

It's not done but I wanted to push this up for others to see, review, and help with as needed.

Note: the text strings (item vs entry) are addressed at #163 