### PR TITLE
Fix telemetry event re-registration in the middle of an existing Firefox session

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -8,85 +8,102 @@ const { utils: Cu } = Components;
 
 Cu.import("resource://gre/modules/Services.jsm");
 
+// In order to allow us to register new telemetry events in the middle of a
+// Firefox session, we currently need to ensure that our events have a unique
+// category name. In order to do this, every time we update the events in any
+// way, we must also give them a unique category name. If you're updating the
+// events, please increment the version number here by 1.
+const TELEMETRY_CATEGORY = "lockboxv0";
+
 function startup({webExtension}, reason) {
-  Services.telemetry.registerEvents("lockbox", {
-    "startup": {
-      methods: ["startup"],
-      objects: ["addon", "webextension"],
-    },
-    "iconClick": {
-      methods: ["iconClick"],
-      objects: ["toolbar"],
-      extra_keys: ["fxauid"],
-    },
-    "displayView": {
-      methods: ["render"],
-      objects: ["firstrun", "manage", "popupUnlock"],
-      extra_keys: ["fxauid"],
-    },
-    "fxaSignIn": {
-      methods: ["render"],
-      objects: ["signInPage"],
-    },
-    "confirmPW": {
-      methods: ["click"],
-      objects: ["confirmPWPage"],
-    },
-    "setupDone": {
-      methods: ["click"],
-      objects: ["setupDoneButton"],
-      extra_keys: ["fxauid"],
-    },
-    "itemAdding": {
-      methods: ["itemAdding"],
-      objects: ["addItemForm"],
-      extra_keys: ["fxauid"],
-    },
-    "itemUpdating": {
-      methods: ["itemUpdating"],
-      objects: ["updatingItemForm"],
-      extra_keys: ["fxauid"],
-    },
-    "itemDeleting": {
-      methods: ["itemDeleting"],
-      objects: ["updatingItemForm"],
-      extra_keys: ["fxauid"],
-    },
-    "itemSelected": {
-      methods: ["itemSelected"],
-      objects: ["itemList"],
-      extra_keys: ["fxauid"],
-    },
-    "addClick": {
-      methods: ["addClick"],
-      objects: ["addButton"],
-      extra_keys: ["fxauid"],
-    },
-    "itemAdded": {
-      methods: ["itemAdded"],
-      objects: ["addItemForm"],
-      extra_keys: ["itemid", "fxauid"],
-    },
-    "datastore": {
-      methods: ["added", "updated", "deleted"],
-      objects: ["datastore"],
-      extra_keys: ["itemid", "fxauid", "fields"],
-    },
-    "feedback": {
-      methods: ["feedbackClick"],
-      objects: ["manage"],
-      extra_keys: ["fxauid"],
-    },
-  });
+  try {
+    Services.telemetry.registerEvents(TELEMETRY_CATEGORY, {
+      "startup": {
+        methods: ["startup"],
+        objects: ["addon", "webextension"],
+      },
+      "iconClick": {
+        methods: ["iconClick"],
+        objects: ["toolbar"],
+        extra_keys: ["fxauid"],
+      },
+      "displayView": {
+        methods: ["render"],
+        objects: ["firstrun", "manage", "popupUnlock"],
+        extra_keys: ["fxauid"],
+      },
+      "fxaSignIn": {
+        methods: ["render"],
+        objects: ["signInPage"],
+      },
+      "confirmPW": {
+        methods: ["click"],
+        objects: ["confirmPWPage"],
+      },
+      "setupDone": {
+        methods: ["click"],
+        objects: ["setupDoneButton"],
+        extra_keys: ["fxauid"],
+      },
+      "itemAdding": {
+        methods: ["itemAdding"],
+        objects: ["addItemForm"],
+        extra_keys: ["fxauid"],
+      },
+      "itemUpdating": {
+        methods: ["itemUpdating"],
+        objects: ["updatingItemForm"],
+        extra_keys: ["fxauid"],
+      },
+      "itemDeleting": {
+        methods: ["itemDeleting"],
+        objects: ["updatingItemForm"],
+        extra_keys: ["fxauid"],
+      },
+      "itemSelected": {
+        methods: ["itemSelected"],
+        objects: ["itemList"],
+        extra_keys: ["fxauid"],
+      },
+      "addClick": {
+        methods: ["addClick"],
+        objects: ["addButton"],
+        extra_keys: ["fxauid"],
+      },
+      "itemAdded": {
+        methods: ["itemAdded"],
+        objects: ["addItemForm"],
+        extra_keys: ["itemid", "fxauid"],
+      },
+      "datastore": {
+        methods: ["added", "updated", "deleted"],
+        objects: ["datastore"],
+        extra_keys: ["itemid", "fxauid", "fields"],
+      },
+      "feedback": {
+        methods: ["feedbackClick"],
+        objects: ["manage"],
+        extra_keys: ["fxauid"],
+      },
+    });
+  } catch (e) {
+    if (e.message === "Attempt to register event that is already registered.") {
+      // eslint-disable-next-line no-console
+      console.log("telemetry events already registered; skipping registration");
+    } else {
+      throw e;
+    }
+  }
 
   webExtension.startup().then(({browser}) => {
     console.log("embedded webextension has started");
-    Services.telemetry.recordEvent("lockbox", "startup", "webextension");
+    Services.telemetry.recordEvent(TELEMETRY_CATEGORY, "startup",
+                                   "webextension");
     browser.runtime.onMessage.addListener((message, sender, respond) => {
       switch (message.type) {
       case "telemetry_event":
         Services.telemetry.recordEvent(
-          message.category, message.method, message.object, null,
+          TELEMETRY_CATEGORY, message.method, message.object, null,
           message.extra || null
         );
         respond({});

--- a/src/webextension/background/browser-action.js
+++ b/src/webextension/background/browser-action.js
@@ -24,7 +24,7 @@ function uninstallPopup() {
 
 function installListener(name) {
   listener = () => {
-    telemetry.recordEvent("lockbox", "iconClick", "toolbar");
+    telemetry.recordEvent("iconClick", "toolbar");
     openView(name);
   };
   browser.browserAction.onClicked.addListener(listener);

--- a/src/webextension/background/datastore.js
+++ b/src/webextension/background/datastore.js
@@ -17,7 +17,7 @@ async function recordMetric(method, itemid, fields) {
       fields,
     };
   }
-  telemetry.recordEvent("lockbox", method, "datastore", extra);
+  telemetry.recordEvent(method, "datastore", extra);
 }
 
 export default async function openDataStore() {

--- a/src/webextension/background/message-ports.js
+++ b/src/webextension/background/message-ports.js
@@ -88,9 +88,8 @@ export default function initializeMessagePorts() {
       });
 
     case "proxy_telemetry_event":
-      return telemetry.recordEvent(
-        message.category, message.method, message.object, message.extra
-      );
+      return telemetry.recordEvent(message.method, message.object,
+                                   message.extra);
     default:
       return null;
     }

--- a/src/webextension/background/telemetry.js
+++ b/src/webextension/background/telemetry.js
@@ -4,13 +4,13 @@
 
 import getAuthorization from "./authorization/index";
 
-export async function recordEvent(category, method, object, extra) {
+export async function recordEvent(method, object, extra) {
   const fxauid = getAuthorization().uid;
   if (fxauid) {
     extra = {...(extra || {}), fxauid};
   }
 
   return browser.runtime.sendMessage({
-    type: "telemetry_event", category, method, object, extra,
+    type: "telemetry_event", method, object, extra,
   });
 }

--- a/src/webextension/firstrun/components/pages.js
+++ b/src/webextension/firstrun/components/pages.js
@@ -24,7 +24,7 @@ export class WelcomePage1 extends React.Component {
   }
 
   async signIn() {
-    telemetry.recordEvent("lockbox", "render", "fxaSignInPage");
+    telemetry.recordEvent("render", "fxaSignInPage");
     try {
       const response = await browser.runtime.sendMessage({
         type: "signin",
@@ -90,7 +90,7 @@ export class VerifyPage2 extends React.Component {
         error: "wrong password",
       });
     }
-    telemetry.recordEvent("lockbox", "click", "confirmPWButton");
+    telemetry.recordEvent("click", "confirmPWButton");
   }
 
   render() {
@@ -137,7 +137,7 @@ export class FinishedPage3 extends React.Component {
       name: "manage",
     });
     this.props.next();
-    telemetry.recordEvent("lockbox", "click", "setupDoneButton");
+    telemetry.recordEvent("click", "setupDoneButton");
   }
 
   render() {

--- a/src/webextension/firstrun/index.js
+++ b/src/webextension/firstrun/index.js
@@ -9,7 +9,7 @@ import AppLocalizationProvider from "../l10n";
 import App from "./components/app";
 import * as telemetry from "../telemetry";
 
-telemetry.recordEvent("lockbox", "render", "firstrun");
+telemetry.recordEvent("render", "firstrun");
 
 ReactDOM.render(
   <AppLocalizationProvider bundles={["firstrun", "widgets"]}

--- a/src/webextension/manage/actions.js
+++ b/src/webextension/manage/actions.js
@@ -62,14 +62,14 @@ export function addItem(details) {
   return async function(dispatch) {
     const actionId = nextActionId++;
     dispatch(addItemStarting(actionId, details));
-    telemetry.recordEvent("lockbox", "itemAdding", "addItemForm");
+    telemetry.recordEvent("itemAdding", "addItemForm");
 
     const response = await browser.runtime.sendMessage({
       type: "add_item",
       item: details,
     });
     dispatch(addItemCompleted(actionId, response.item));
-    telemetry.recordEvent("lockbox", "itemAdded", "addItemForm");
+    telemetry.recordEvent("itemAdded", "addItemForm");
   };
 }
 
@@ -97,7 +97,7 @@ export function updateItem(item) {
   return async function(dispatch) {
     const actionId = nextActionId++;
     dispatch(updateItemStarting(actionId, item));
-    telemetry.recordEvent("lockbox", "itemUpdating", "updatingItemForm");
+    telemetry.recordEvent("itemUpdating", "updatingItemForm");
 
     const response = await browser.runtime.sendMessage({
       type: "update_item",
@@ -131,7 +131,7 @@ export function removeItem(id) {
   return async function(dispatch) {
     const actionId = nextActionId++;
     dispatch(removeItemStarting(actionId, id));
-    telemetry.recordEvent("lockbox", "itemDeleting", "updatingItemForm");
+    telemetry.recordEvent("itemDeleting", "updatingItemForm");
 
     await browser.runtime.sendMessage({
       type: "remove_item",
@@ -176,7 +176,7 @@ export function selectItem(id) {
       id,
     });
     dispatch(selectItemCompleted(actionId, response.item));
-    telemetry.recordEvent("lockbox", "itemSelected", "itemList");
+    telemetry.recordEvent("itemSelected", "itemList");
   };
 }
 

--- a/src/webextension/manage/components/send-feedback.js
+++ b/src/webextension/manage/components/send-feedback.js
@@ -12,7 +12,7 @@ const FEEDBACK_URL = "https://qsurvey.mozilla.com/s3/Lockbox-Input";
 
 export default function SendFeedback() {
   const doClick = () => {
-    telemetry.recordEvent("lockbox", "feedbackClick", "manage");
+    telemetry.recordEvent("feedbackClick", "manage");
     window.open(FEEDBACK_URL, "_blank");
   };
 

--- a/src/webextension/manage/containers/add-item.js
+++ b/src/webextension/manage/containers/add-item.js
@@ -13,7 +13,7 @@ import * as telemetry from "../../telemetry";
 
 function AddItem({dispatch}) {
   const doClick = () => {
-    telemetry.recordEvent("lockbox", "addClick", "addButton");
+    telemetry.recordEvent("addClick", "addButton");
     dispatch(startNewItem());
   };
 

--- a/src/webextension/manage/index.js
+++ b/src/webextension/manage/index.js
@@ -19,7 +19,7 @@ const store = createStore(reducer, undefined, applyMiddleware(thunk));
 store.dispatch(listItems());
 initializeMessagePorts(store);
 
-telemetry.recordEvent("lockbox", "render", "manage");
+telemetry.recordEvent("render", "manage");
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/webextension/popup/unlock/index.js
+++ b/src/webextension/popup/unlock/index.js
@@ -9,9 +9,9 @@ import AppLocalizationProvider from "../../l10n";
 import App from "./components/app";
 import * as telemetry from "../../telemetry";
 
-// this is the closest approximation we can get to a toolbar click when
-// the popup is registered
-telemetry.recordEvent("lockbox", "render", "popupUnlock");
+// This is the closest approximation we can get to a toolbar click when the
+// popup is registered.
+telemetry.recordEvent("render", "popupUnlock");
 
 ReactDOM.render(
   <AppLocalizationProvider bundles={["popup", "widgets"]}

--- a/src/webextension/telemetry.js
+++ b/src/webextension/telemetry.js
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export async function recordEvent(category, method, object, extra) {
+export async function recordEvent(method, object, extra) {
   return browser.runtime.sendMessage({
-    type: "proxy_telemetry_event", category, method, object, extra,
+    type: "proxy_telemetry_event", method, object, extra,
   });
 }

--- a/test/background/message-ports-test.js
+++ b/test/background/message-ports-test.js
@@ -214,7 +214,6 @@ describe("background > message ports", () => {
     initializeMessagePorts.__Rewire__("telemetry", {recordEvent});
     const result = await browser.runtime.sendMessage({
       type: "proxy_telemetry_event",
-      category: "category",
       method: "method",
       object: "object",
       extra: {extra: "value"},
@@ -222,7 +221,7 @@ describe("background > message ports", () => {
     initializeMessagePorts.__ResetDependency__("telemetry");
 
     expect(result).to.deep.equal({});
-    expect(recordEvent).to.have.been.calledWith("category", "method", "object",
+    expect(recordEvent).to.have.been.calledWith("method", "object",
                                                 {extra: "value"});
   });
 

--- a/test/background/telemetry-test.js
+++ b/test/background/telemetry-test.js
@@ -26,12 +26,10 @@ describe("background > telemetry", () => {
 
   describe("no fxa uid", () => {
     it("recordEvent()", async() => {
-      const result = await telemetry.recordEvent("category", "method",
-                                                 "object");
+      const result = await telemetry.recordEvent("method", "object");
       expect(result).to.deep.equal({});
       expect(onMessage).to.have.been.calledWith({
         type: "telemetry_event",
-        category: "category",
         method: "method",
         object: "object",
         extra: undefined,
@@ -39,12 +37,11 @@ describe("background > telemetry", () => {
     });
 
     it("recordEvent() with extra", async() => {
-      const result = await telemetry.recordEvent("category", "method", "object",
+      const result = await telemetry.recordEvent("method", "object",
                                                  {extra: "value"});
       expect(result).to.deep.equal({});
       expect(onMessage).to.have.been.calledWith({
         type: "telemetry_event",
-        category: "category",
         method: "method",
         object: "object",
         extra: {extra: "value"},
@@ -65,12 +62,10 @@ describe("background > telemetry", () => {
     });
 
     it("recordEvent() (with fxa uid)", async() => {
-      const result = await telemetry.recordEvent("category", "method",
-                                                 "object");
+      const result = await telemetry.recordEvent("method", "object");
       expect(result).to.deep.equal({});
       expect(onMessage).to.have.been.calledWith({
         type: "telemetry_event",
-        category: "category",
         method: "method",
         object: "object",
         extra: {fxauid: "1234"},
@@ -78,12 +73,11 @@ describe("background > telemetry", () => {
     });
 
     it("recordEvent() (with fxa uid and extras)", async() => {
-      const result = await telemetry.recordEvent("category", "method", "object",
+      const result = await telemetry.recordEvent("method", "object",
                                                  {extra: "value"});
       expect(result).to.deep.equal({});
       expect(onMessage).to.have.been.calledWith({
         type: "telemetry_event",
-        category: "category",
         method: "method",
         object: "object",
         extra: {extra: "value", fxauid: "1234"},

--- a/test/bootstrap-test.js
+++ b/test/bootstrap-test.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* global Services */
+
 require("babel-polyfill");
 
 import waitUntil from "async-wait-until";
@@ -14,16 +16,51 @@ chai.use(sinonChai);
 import bootstrap from "src/bootstrap";
 
 describe("bootstrap", () => {
-  it("startup()", async() => {
+  describe("startup()", () => {
     const startup = bootstrap.__get__("startup");
-    const webextStartup = sinon.stub().resolves({browser});
-    startup({webExtension: {
-      startup: webextStartup,
-    }});
+    let webextStartup;
 
-    await waitUntil(() => webextStartup.callCount === 1);
-    const result = await browser.runtime.sendMessage({type: "telemetry_event"});
-    expect(result).to.deep.equal({});
+    beforeEach(() => {
+      webextStartup = sinon.stub().resolves({browser});
+    });
+
+    afterEach(() => {
+      // Clear the listeners set in <src/bootstrap.js>.
+      browser.runtime.onMessage.mockClearListener();
+    });
+
+    it("web extension loaded and telemetry recorded", async() => {
+      const webextStartup = sinon.stub().resolves({browser});
+      startup({webExtension: {
+        startup: webextStartup,
+      }});
+
+      await waitUntil(() => webextStartup.callCount === 1);
+      const result = await browser.runtime.sendMessage(
+        {type: "telemetry_event"}
+      );
+      expect(result).to.deep.equal({});
+    });
+
+    it("re-registering telemetry doesn't throw", () => {
+      sinon.stub(Services.telemetry, "registerEvents").throws(new Error(
+        "Attempt to register event that is already registered."
+      ));
+      expect(() => startup({webExtension: {
+        startup: webextStartup,
+      }})).to.not.throw();
+      Services.telemetry.registerEvents.restore();
+    });
+
+    it("other errors do throw", () => {
+      sinon.stub(Services.telemetry, "registerEvents").throws(new Error(
+        "something else"
+      ));
+      expect(() => startup({webExtension: {
+        startup: webextStartup,
+      }})).to.throw();
+      Services.telemetry.registerEvents.restore();
+    });
   });
 
   // These functions are currently no-ops, so we just need to test that they

--- a/test/telemetry-test.js
+++ b/test/telemetry-test.js
@@ -24,12 +24,11 @@ describe("telemetry", () => {
   });
 
   it("recordEvent()", async() => {
-    const result = await telemetry.recordEvent("category", "method", "object",
+    const result = await telemetry.recordEvent("method", "object",
                                                {extra: "value"});
     expect(result).to.deep.equal({});
     expect(onMessage).to.have.been.calledWith({
       type: "proxy_telemetry_event",
-      category: "category",
       method: "method",
       object: "object",
       extra: {extra: "value"},


### PR DESCRIPTION
As discussed on Slack. Here's a quick fix that just makes our telemetry category versioned. This will break the other telemetry PR, so I'll land this after and fix stuff up myself.