### PR TITLE
Fix indentation in FTL files

### DIFF
--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -1,13 +1,15 @@
-toolbar-item-count = { $count ->
-   [one]   1 Entry
-  *[other] { $count } Entries
-}
+toolbar-item-count =
+  { $count ->
+     [one]   1 Entry
+    *[other] { $count } Entries
+  }
 
 toolbar-add-item = New Entry
 toolbar-go-home = Home
 toolbar-send-feedback = Feedback
 
-item-filter.placeholder = Search for an entry
+item-filter
+  .placeholder = Search for an entry
 
 item-summary-new-item = New Entry
 item-summary-no-title = (No Entry Name)
@@ -19,14 +21,15 @@ homepage-no-passwords =
   
   To get started, click { toolbar-add-item } above.
 
-homepage-under-10-passwords = { $count ->
-   [1]     Hi there! It's your friend, Lockie!
+homepage-under-10-passwords =
+  { $count ->
+     [1]     Hi there! It's your friend, Lockie!
            
-           You've added { $count } entry. That's a great start!
-  *[other] Hi there! It's your friend, Lockie!
+             You've added { $count } entry. That's a great start!
+    *[other] Hi there! It's your friend, Lockie!
            
-           You've added { $count } entries. That's a great start!
-}
+             You've added { $count } entries. That's a great start!
+  }
 
 homepage-under-50-passwords =
   Hey again! Just your pal Lockie checking in!


### PR DESCRIPTION
Fixes #222 

In FTL, multiline translations must currently be indented by at least one space, including the closing `}` in select expressions.