### PR TITLE
Use ~ for fluent dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     ]
   },
   "dependencies": {
-    "fluent": "^0.4.1",
-    "fluent-intl-polyfill": "^0.1.0",
-    "fluent-langneg": "^0.1.0",
-    "fluent-react": "^0.4.1",
+    "fluent": "~0.4.1",
+    "fluent-intl-polyfill": "~0.1.0",
+    "fluent-langneg": "~0.1.0",
+    "fluent-react": "~0.4.1",
     "intl-pluralrules": "^0.1.0",
     "lockbox-datastore": "git+https://github.com/mozilla-lockbox/lockbox-datastore.git",
     "node-jose": "^0.10.0",


### PR DESCRIPTION
Since fluent is still in its 0.x days, I suggest to only allow automatic
upgrades to the most recent PATCH versions. That's what the ~ operator
does in package.json. MINOR versions (allowed by ^) might introduce API
incompatibilities.