### PR TITLE
Improve first-run tests slightly

### DIFF
--- a/src/webextension/firstrun/components/master-password-setup.js
+++ b/src/webextension/firstrun/components/master-password-setup.js
@@ -14,7 +14,10 @@ import styles from "./master-password-setup.css";
 export default class MasterPasswordSetup extends React.Component {
   constructor() {
     super();
-    this.state = {};
+    this.state = {
+      password: "",
+      confirmPassword: "",
+    };
   }
 
   componentDidMount() {

--- a/test/bootstrap-test.js
+++ b/test/bootstrap-test.js
@@ -35,7 +35,6 @@ describe("bootstrap", () => {
     });
 
     it("web extension loaded and telemetry recorded", async() => {
-      const webextStartup = sinon.stub().resolves({browser});
       startup({webExtension: {
         startup: webextStartup,
       }});
@@ -47,7 +46,7 @@ describe("bootstrap", () => {
       expect(result).to.deep.equal({});
     });
 
-    it("re-registering telemetry doesn't throw", () => {
+    it("re-registering telemetry doesn't throw", async() => {
       sinon.stub(Services.telemetry, "registerEvents").throws(new Error(
         "Attempt to register event that is already registered."
       ));
@@ -55,6 +54,8 @@ describe("bootstrap", () => {
         startup: webextStartup,
       }})).to.not.throw();
       Services.telemetry.registerEvents.restore();
+
+      await waitUntil(() => webextStartup.callCount === 1);
     });
 
     it("other errors do throw", () => {

--- a/test/firstrun/components/master-password-setup-test.js
+++ b/test/firstrun/components/master-password-setup-test.js
@@ -48,4 +48,16 @@ describe("firstrun > components > master-password-setup", () => {
       "error", "Passwords do not match"
     );
   });
+
+  it("catch failures to initialize", async() => {
+    browser.runtime.onMessage.mockClearListener();
+    browser.runtime.onMessage.addListener(() => {
+      throw new Error();
+    });
+    wrapper.find('button[type="submit"]').simulate("submit");
+    await waitUntil(() => MasterPasswordSetup.prototype.render.callCount === 2);
+    expect(wrapper).to.have.state(
+      "error", "Could not initialize!"
+    );
+  });
 });


### PR DESCRIPTION
This fixes a minor issue where `<MasterPasswordSetup/>` wasn't always using controlled fields in React and adds a test to get us to that coveted 100% coverage. I also fixed an issue with clearing event listeners in the bootstrap.js tests.