### PR TITLE
Disable the Firefox built-in password manager on install; resolves #184

### DIFF
--- a/test/mocks/xpcom.js
+++ b/test/mocks/xpcom.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+window.ADDON_INSTALL = "ADDON_INSTALL";
+
 window.Components = {
   utils: {
     "import": function() {},
@@ -9,6 +11,30 @@ window.Components = {
 };
 
 window.Services = {
+  prefs: {
+    _prefs: {},
+
+    getBoolPref(key) {
+      return this._prefs[key] || false;
+    },
+
+    setBoolPref(key, value) {
+      this._prefs[key] = value;
+    },
+
+    clearUserPref(key) {
+      delete this._prefs[key];
+    },
+
+    prefHasUserValue(key) {
+      return key in this._prefs;
+    },
+
+    mockResetPrefs() {
+      this._prefs = {};
+    },
+  },
+
   telemetry: {
     registerEvents() {},
     recordEvent() {},


### PR DESCRIPTION
Note that this only applies to *new* installs of Lockbox, so existing users will want to uninstall Lockbox, restart Firefox, and reinstall. This is slightly inconvenient, but shouldn't be a problem in the long term.