### PR TITLE
Remove usage of withLocalization()/getString() from the item list

### DIFF
--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -20,9 +20,17 @@ all-items-empty =
   Create a new entry so Lockie has something to protect.
 all-items-filtered = No results
 
-item-summary-new-item = New Entry
-item-summary-no-title = (No Entry Name)
-item-summary-no-username = (No Username)
+item-summary-new-title = New Entry
+item-summary-title =
+  { $length ->
+     [0]     (No Entry Name)
+    *[other] { $title }
+  }
+item-summary-username =
+  { $length ->
+     [0]     (No Username)
+    *[other] { username }
+  }
 
 homepage-no-passwords =
   Welcome to Lockbox! I'm Lockie, and I'm here to help you lock

--- a/src/webextension/manage/components/item-list.js
+++ b/src/webextension/manage/components/item-list.js
@@ -14,9 +14,9 @@ export default function ItemList({items, selected, onItemSelected}) {
   return (
     <ScrollingList itemClassName={styles.item} data={items} selected={selected}
                    onItemSelected={onItemSelected}>
-      {({title, username}) => {
+      {({id, title, username}) => {
         return (
-          <ItemSummary title={title} username={username}/>
+          <ItemSummary id={id} title={title} username={username}/>
         );
       }}
     </ScrollingList>

--- a/src/webextension/manage/components/item-summary.js
+++ b/src/webextension/manage/components/item-summary.js
@@ -2,35 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { withLocalization } from "fluent-react";
+import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { NEW_ITEM_ID } from "../common";
 import styles from "./item-summary.css";
 
-function ItemSummary({title, username, getString}) {
+export default function ItemSummary({id, title, username}) {
+  title = title.trim();
+  username = username.trim();
+
+  const titleId = `item-summary-${id === NEW_ITEM_ID ? "new-title" : "title"}`;
   return (
     <div className={styles.itemSummary}>
-      <div className={styles.title}>
-        {title.trim() || getString("item-summary-no-title")}
-      </div>
-      <div className={styles.subtitle}>
-        {username.trim() || getString("item-summary-no-username")}
-      </div>
+      <Localized id={titleId} $title={title} $length={title.length}>
+        <div className={styles.title}>no tITLe</div>
+      </Localized>
+      <Localized id="item-summary-username" $username={username}
+                 $length={username.length}>
+        <div className={styles.subtitle}>no uSERNAMe</div>
+      </Localized>
     </div>
   );
 }
 
 ItemSummary.propTypes = {
+  id: PropTypes.string,
   title: PropTypes.string,
   username: PropTypes.string,
-  getString: PropTypes.func.isRequired,
 };
 
 ItemSummary.defaultProps = {
+  id: null,
   title: "",
   username: "",
-  selected: false,
 };
-
-export default withLocalization(ItemSummary);

--- a/test/manage/components/item-summary-test.js
+++ b/test/manage/components/item-summary-test.js
@@ -2,30 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect } from "chai";
+import chai, { expect } from "chai";
+import chaiEnzyme from "chai-enzyme";
+import { Localized } from "fluent-react";
 import React from "react";
 
 import mountWithL10n from "test/mocks/l10n";
+import { NEW_ITEM_ID } from "src/webextension/manage/common";
 import ItemSummary from "src/webextension/manage/components/item-summary";
 
+chai.use(chaiEnzyme());
+
 describe("manage > components > <ItemSummary/>", () => {
-  it("render title and username", () => {
+  it("render existing item", () => {
     const wrapper = mountWithL10n(
       <ItemSummary title="title" username="username"/>
     );
-    expect(wrapper.find("div > div").at(0).text()).to.equal("title");
-    expect(wrapper.find("div > div").at(1).text()).to.equal("username");
+    expect(wrapper.find(Localized).at(0)).to.have.prop(
+      "id", "item-summary-title"
+    );
+    expect(wrapper.find(Localized).at(1)).to.have.prop(
+      "id", "item-summary-username"
+    );
   });
 
-  it("render blank", () => {
+  it("render new item", () => {
     const wrapper = mountWithL10n(
-      <ItemSummary/>
+      <ItemSummary id={NEW_ITEM_ID}/>
     );
-    expect(wrapper.find("div > div").at(0).text()).to.equal(
-      "item-summary-no-title"
+    expect(wrapper.find(Localized).at(0)).to.have.prop(
+      "id", "item-summary-new-title"
     );
-    expect(wrapper.find("div > div").at(1).text()).to.equal(
-      "item-summary-no-username"
+    expect(wrapper.find(Localized).at(1)).to.have.prop(
+      "id", "item-summary-username"
     );
   });
 });

--- a/test/manage/containers/all-items-test.js
+++ b/test/manage/containers/all-items-test.js
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect } from "chai";
+import chai, { expect } from "chai";
+import chaiEnzyme from "chai-enzyme";
+import { Localized } from "fluent-react";
 import React from "react";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
@@ -14,6 +16,8 @@ import ItemSummary from "src/webextension/manage/components/item-summary";
 import AllItems from "src/webextension/manage/containers/all-items";
 import { SELECT_ITEM_STARTING } from "src/webextension/manage/actions";
 import { NEW_ITEM_ID } from "src/webextension/manage/common";
+
+chai.use(chaiEnzyme());
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -114,7 +118,9 @@ describe("manage > containers > <AllItems/>", () => {
     it("render items", () => {
       const item = wrapper.find(ItemSummary);
       expect(item).to.have.length(1);
-      expect(item.prop("title")).to.equal("item-summary-new-item");
+      expect(item.find(Localized).at(0)).to.have.prop(
+        "id", "item-summary-new-title"
+      );
     });
   });
 });


### PR DESCRIPTION
I'd like to remove `withLocalization()`/`getString()` wherever possible. This removes it for the item list.

@stasm Is there a better way to handle the localization here? I want to have a fallback string when the user-defined string is empty, but the only way I could get to work was to pass the string's length in separately and select based on that.