### PR TITLE
Remove some unnecessary console.log calls

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -101,7 +101,6 @@ function startup({webExtension}, reason) {
   }
 
   webExtension.startup().then(({browser}) => {
-    console.log("embedded webextension has started");
     Services.telemetry.recordEvent(TELEMETRY_CATEGORY, "startup",
                                    "webextension");
     browser.runtime.onMessage.addListener((message, sender, respond) => {
@@ -121,7 +120,6 @@ function shutdown(data, reason) {}
 
 function install(data, reason) {
   if (reason === ADDON_INSTALL) {
-    console.log("INSTALLING...");
     // Remember the original value for `signons.rememberSignons` so we can
     // restore it during uninstall, then disable it so it doesn't conflict with
     // us.

--- a/src/webextension/background/browser-action.js
+++ b/src/webextension/background/browser-action.js
@@ -48,14 +48,11 @@ export default async function updateBrowserAction(ds) {
 
   if (!ds.initialized) {
     // setup first-run popup
-    console.log("setup first run click handler");
     return installListener("firstrun");
   } else if (ds.locked) {
     // setup unlock popup
-    console.log("setup unlock popup");
     return installPopup("popup/unlock/index.html");
   }
 
-  console.log("setup on click handler");
   return installListener("manage");
 }

--- a/src/webextension/background/index.js
+++ b/src/webextension/background/index.js
@@ -9,14 +9,16 @@ import updateBrowserAction from "./browser-action";
 
 // XXX: For now, initialize the datastore on startup and then hook up the
 // button. Eventually, we'll have UX to create new datastores (and persist
-// existing ones).\
+// existing ones).
 openDataStore().then(async(ds) => {
   try {
     // attempt to load authorization (FxA) data
     let authz = await loadAuthorization(browser.storage.local);
+    // eslint-disable-next-line no-console
     console.log(`loaded authorization for ${authz.uid}`);
   } catch (err) {
-    console.log(`loading failed: ${err.message}`);
+    // eslint-disable-next-line no-console
+    console.error(`loading failed: ${err.message}`);
   }
 
   initializeMessagePorts();

--- a/src/webextension/background/views.js
+++ b/src/webextension/background/views.js
@@ -44,7 +44,8 @@ export class SingletonView {
       (this.id !== undefined) && await browser.tabs.remove(this.id);
     } catch (err) {
       // Q: loggit?
-      console.log(`could not close ${this.path} view: ${err.message}`);
+      // eslint-disable-next-line no-console
+      console.error(`could not close ${this.path} view: ${err.message}`);
     }
     this.id = undefined;
     return this;
@@ -57,13 +58,11 @@ const views = {
 };
 
 export async function openView(name) {
-  console.log(`opening view for ${name} ...`);
   const v = views[name];
   return v.open();
 }
 
 export async function closeView(name) {
-  console.log(`closing view(s) for ${name} ...`);
   const v = views[name];
   return v.close();
 }

--- a/src/webextension/firstrun/components/master-password-setup.js
+++ b/src/webextension/firstrun/components/master-password-setup.js
@@ -57,7 +57,8 @@ export default class MasterPasswordSetup extends React.Component {
           name: "firstrun",
         });
       } catch (err) {
-        console.log(`initialize failed: ${err.message}`);
+        // eslint-disable-next-line no-console
+        console.error(`initialize failed: ${err.message}`);
         // TODO: Localize this!
         this.setState({
           error: "Could not initialize!",


### PR DESCRIPTION
This just removes some logging and disables warnings for some other ones. I'm totally willing to debate which logging should be kept around, but I mainly went with just keeping error logging around.

With this patch, there are 0 eslint warnings, so maybe we could even make `console.log` usage throw an eslint error now. (It'll still warn on local builds, since we run lint in warn-only mode there.)