### PR TITLE
Use rjsx-mode for JS files in src/webextension

### DIFF
--- a/src/webextension/.dir-locals.el
+++ b/src/webextension/.dir-locals.el
@@ -1,0 +1,2 @@
+; Use rjsx-mode instead of js2-mode for files in this directory.
+((js2-mode . ((mode . rjsx))))


### PR DESCRIPTION
This makes my life easier (and presumably the lives of other emacs users). It should only trigger if you have js2-mode installed, but assumes you also have rjsx-mode installed.