### PR TITLE
Fix UI color issues with GTK theme, fixes #264

### DIFF
--- a/src/webextension/widgets/button.css
+++ b/src/webextension/widgets/button.css
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+button,
+.button {
+  color: #222426;
+}
+
 button.button {
   white-space: nowrap;
   /* Override the margin-bottom from browser-style. */

--- a/src/webextension/widgets/dialog-box.css
+++ b/src/webextension/widgets/dialog-box.css
@@ -5,6 +5,8 @@
 .modal-dialog {
   padding: 1em;
   border: 1px solid ActiveBorder;
+
+  background-color: #E8E8E7;
 }
 
 .modal-dialog > menu {

--- a/src/webextension/widgets/input.css
+++ b/src/webextension/widgets/input.css
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+input,
+.input {
+  color: #222426;
+}
+
 span.input {
   /* Override the margin-bottom from browser-style. */
   margin-bottom: 0;

--- a/src/webextension/widgets/password-input.css
+++ b/src/webextension/widgets/password-input.css
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+.password-input input[type="password"] {
+  color: #222426;
+}
+
 .password-input {
   display: flex;
 }

--- a/src/webextension/widgets/scrolling-list.css
+++ b/src/webextension/widgets/scrolling-list.css
@@ -15,8 +15,8 @@
 }
 
 .scrolling-list > li[data-selected] {
-  color: InactiveCaptionText;
-  background-color: InactiveCaption;
+  color: #8B8E8F;
+  background-color: #E8E8E7;
 }
 
 .scrolling-list:focus > li[data-selected] {

--- a/src/webextension/widgets/text-area.css
+++ b/src/webextension/widgets/text-area.css
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+textarea,
+.text-area {
+  color: #222426;
+}
+
 textarea.text-area {
   /* Override the margin-bottom from browser-style. */
   margin-bottom: 0;


### PR DESCRIPTION
This pull request fixes UI issues caused by GTK themes, discussed here: #264  
Please reference this issue to see the screenshots of the state before this pull request.

## Changes
This pull request changed some stylesheet properties to ensure the color is correct.

Currently, some hardcoded color values have been used to achieve this. Because things like `color: InactiveCaptionText;` don't seem to work consistently. Please let me know if this isn't desired, there might be another solution for that.

## New Screenshots
Let's take a look at the fixed styles below, or view the [full-page screenshot](https://uploads.timvisee.com/public/firefox-lockbox-fix-full-b7ed0340.png).

### Sidebar
![Sidebar screenshot](https://uploads.timvisee.com/public/firefox-lockbox-fix-sidebar-89f598af.png)
- The search bar (and _Clear_ button) are now readable.
- The entry selection color is now consistent with the default.

### Edit
![Edit screenshot](https://uploads.timvisee.com/public/firefox-lockbox-fix-edit-43a98b37.png)
- Fields are now readable.
- The _Show_ and _Cancel_ button are now readable.

### Top bar
![Top bar screenshot](https://uploads.timvisee.com/public/firefox-lockbox-fix-topbar-f2ca71ce.png)
- Action buttons in the top bar are now readable.

### Dialog box
![Dialog box screenshot](https://uploads.timvisee.com/public/firefox-lockbox-fix-dialog-a373daa9.png)
- Dialog box backgrounds are now consistent with the default.
- The _Cancel_ button is now readable.