### PR TITLE
Pre-release notes to include and push in 0.1.1-alpha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Lockbox for Firefox is a work-in-progress extension for Firefox to improve upon
 Firefox's built-in password management. If you're interested, you should
 probably come back later when we have more to show!
 
+:warning: **Note: This is a rapidly evolving prototype that will change. Any
+data stored here is not guaranteed to be retained in future updates.**
+
 ## [Quick Installation][install-link]
 
 If you'd like to quickly **start up a new Firefox profile on Nightly** with

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,5 +6,5 @@ Click below to install the Lockbox extension:
 
 [install-link]: https://testpilot.firefox.com/files/lockbox@mozilla.com/latest
 
-Note: This is a rapidly evolving prototype that will change. Any data stored is
-not guaranteed to be retained in future updates.
+**Note: This is a rapidly evolving prototype that will change. Any data stored
+is not guaranteed to be retained in future updates.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,6 @@ Click below to install the Lockbox extension:
 [install][install-link]{: .button-link }
 
 [install-link]: https://testpilot.firefox.com/files/lockbox@mozilla.com/latest
+
+Note: This is a rapidly evolving prototype that will change. Any data stored is
+not guaranteed to be retained in future updates.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,20 @@
 # Lockbox Release Notes
 
+## 0.1.1-alpha1
+
+_Date: 2017-11-01_
+
+### What's Fixed
+
+* We added language to the first-run experience to remind testers that this is pre-release software and both **subject to change and data may not be retained**.
+
+### Known Issues
+
+* There is no way to change your Lockbox master password.  If you forget your master password, you'll need to start over fresh by either:
+  - Opening the this extension's Preferences and clicking the "`💥💣 Reset 💣💥`" button; or
+  - Uninstalling and re-installing the extension
+* Firefox's default prompt to save logins is only disabled on new installs of this extension; updating Lockbox will not change your current Firefox preferences.
+
 ## 0.1.1-alpha
 
 _Date: 2017-10-30_
@@ -43,6 +58,6 @@ This starts as a signed Firefox extension where you can:
 
 ### Known Issues
 
-* Lockbox has only been tested on Firefox 57 and above.  Installing on Firefox 56 or lower may not function at all. 
+* Lockbox has only been tested on Firefox 57 and above.  Installing on Firefox 56 or lower may not function at all.
 * There is no way to reset your Lockbox master password. If you forget your master password, you'll need to start over fresh by uninstalling and re-installing this extension.
 * This is a Lockbox account, which stays local to your Firefox installation. There is no integration with Firefox accounts to sync (yet).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lockbox",
-  "version": "0.1.1-alpha",
+  "version": "0.1.1-alpha1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "title": "Lockbox",
   "name": "lockbox",
   "id": "lockbox@mozilla.com",
-  "version": "0.1.1-alpha",
+  "version": "0.1.1-alpha1",
   "main": "dist/bootstrap.js",
   "description": "A Lockbox extension for Firefox",
   "author": "Lockbox Team <lockbox-dev@mozilla.com>",


### PR DESCRIPTION
Fast follow to #275, also fixes #270

Very minor point release that includes "this is a pre-release" language in the product and docs to remind any users this is subject to change and data may not be retained.

@sandysage I took a quick pass assuming this is what you'd want to say and how to say it. Please feel free to make any other edits directly to this branch.

Once approved by @mozilla-lockbox/product-integrity and @mozilla-lockbox/engineering and @sandysage we can merge to master, along with #275 and then create PR to merge master into production (thus creating the point release). 
