### PR TITLE
Cherry pick and deploy 0.1.1-alpha1 to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Lockbox for Firefox is a work-in-progress extension for Firefox to improve upon
 Firefox's built-in password management. If you're interested, you should
 probably come back later when we have more to show!
 
+:warning: **Note: This is a rapidly evolving prototype that will change. Any
+data stored here is not guaranteed to be retained in future updates.**
+
 ## [Quick Installation][install-link]
 
 If you'd like to quickly **start up a new Firefox profile on Nightly** with

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,6 @@ Click below to install the Lockbox extension:
 [install][install-link]{: .button-link }
 
 [install-link]: https://testpilot.firefox.com/files/lockbox@mozilla.com/latest
+
+**Note: This is a rapidly evolving prototype that will change. Any data stored
+is not guaranteed to be retained in future updates.**

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,20 @@
 # Lockbox Release Notes
 
+## 0.1.1-alpha1
+
+_Date: 2017-11-01_
+
+### What's Fixed
+
+* We added language to the first-run experience to remind testers that this is pre-release software and both **subject to change and data may not be retained**.
+
+### Known Issues
+
+* There is no way to change your Lockbox master password.  If you forget your master password, you'll need to start over fresh by either:
+  - Opening the this extension's Preferences and clicking the "`💥💣 Reset 💣💥`" button; or
+  - Uninstalling and re-installing the extension
+* Firefox's default prompt to save logins is only disabled on new installs of this extension; updating Lockbox will not change your current Firefox preferences.
+
 ## 0.1.1-alpha
 
 _Date: 2017-10-30_
@@ -43,6 +58,6 @@ This starts as a signed Firefox extension where you can:
 
 ### Known Issues
 
-* Lockbox has only been tested on Firefox 57 and above.  Installing on Firefox 56 or lower may not function at all. 
+* Lockbox has only been tested on Firefox 57 and above.  Installing on Firefox 56 or lower may not function at all.
 * There is no way to reset your Lockbox master password. If you forget your master password, you'll need to start over fresh by uninstalling and re-installing this extension.
 * This is a Lockbox account, which stays local to your Firefox installation. There is no integration with Firefox accounts to sync (yet).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lockbox",
-  "version": "0.1.1-alpha",
+  "version": "0.1.1-alpha1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "title": "Lockbox",
   "name": "lockbox",
   "id": "lockbox@mozilla.com",
-  "version": "0.1.1-alpha",
+  "version": "0.1.1-alpha1",
   "main": "dist/bootstrap.js",
   "description": "A Lockbox extension for Firefox",
   "author": "Lockbox Team <lockbox-dev@mozilla.com>",

--- a/src/webextension/firstrun/components/welcome.js
+++ b/src/webextension/firstrun/components/welcome.js
@@ -20,6 +20,15 @@ export default function Welcome() {
         adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Cras
         mattis consectetur purus sit amet fermentum.</p>
       </Localized>
+      <p>
+        <Localized id="welcome-warning">
+          <strong>Lorem ipsum dolor sit amet, consectetur.
+          Mauris, aliquam vel pellentesque et, mattis bibendum tellus. Fusce
+          sodales, tellus a auctor accumsan, diam risus pharetra orci, at lacinia
+          libero eros ut erat. Fusce ex neque, pharetra id rhoncus in,
+          pellentesque quis urna.</strong>
+        </Localized>
+      </p>
       <Localized id="welcome-feedback">
         <p>Curabitur blandit tempus porttitor. Nulla vitae elit libero, a
         pharetra augue. Vestibulum id ligula porta felis euismod semper.

--- a/src/webextension/locales/en-US/firstrun.ftl
+++ b/src/webextension/locales/en-US/firstrun.ftl
@@ -9,10 +9,14 @@ welcome-intro =
     new entries, and then later you can view, search, edit, and
     delete those entries.
 
+welcome-warning =
+    This is a rapidly evolving prototype that will change as Alpha progresses.
+    Any data stored here is not guaranteed to be retained in future updates.
+
 welcome-feedback =
     Please be sure to let us know your thoughts using our feedback
     button within the tool, including any issues you may find, things
-    you like, and the things you're looking forward in the future.
+    you like, and the things you're looking forward to in the future.
 
 master-password-setup-formtitle = Please create a master password below:
 


### PR DESCRIPTION
I created the `0.1.1-alpha1-prod` branch and cherry-picked my two squashed commits since I don't want to pull _everything_ from `master` branch yet (dependency updates, empty sidebar).

This may be overly cautious but I think of it as our own version of doing an uplift and a point release.

Can I get a 👍 from @m8ttyB that we're still good for just these two commits (only) to go into production as a point release?

Once we hit the big green button ✅ this will be live and update any existing installations. Cool?