### PR TITLE
Always request review from PI

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,9 +1,6 @@
 # lockbox-extension code owners
 # https://help.github.com/articles/about-codeowners/
 
-# tests should also be reviewed by @m8ttyB
-/test/    @jimporter @m8ttyB
-
 # docs are shepherded by @devinreams
 /docs/    @jimporter @devinreams
 

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,9 +1,6 @@
 # lockbox-extension code owners
 # https://help.github.com/articles/about-codeowners/
 
-# docs are shepherded by @devinreams
-/docs/    @jimporter @devinreams
-
 # include Flod for l10n string changes
 # @todo uncomment below after initial string freeze
 #src/webextension/locales/en-US/*.ftl    @flodolo

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -11,5 +11,6 @@
 # @todo uncomment below after initial string freeze
 #src/webextension/locales/en-US/*.ftl    @flodolo
 
-# otherwise, everything is to be reviewed by @jimporter
-*         @jimporter
+# everything is to be reviewed by @jimporter
+# also, default to always include PI
+*         @jimporter @mozilla-lockbox/product-integrity


### PR DESCRIPTION
After discussion with @m8ttyB I'd like to propose we default to _always_ automatically request review from the @mozilla-lockbox/product-integrity team on all code on all PRs.

This way we can be explicit about sign-offs per feature before they go into the `master` branch (which we intend to be stage-able or deploy-able at any time). That way any manual test steps are added/accounted for and performed and unit/integration tests are considered.

I open it up to you all, what do you think? I'd like to incorporate a decision or any changes discussed here into my process doc draft before we meet as a team on Monday.

