### PR TITLE
Fix bad translation of item summary username

### DIFF
--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -28,7 +28,7 @@ item-summary-title =
 item-summary-username =
   { $length ->
      [0]     (No Username)
-    *[other] { username }
+    *[other] { $username }
   }
 
 homepage-title =


### PR DESCRIPTION
`$username` and `username` are very different!