### PR TITLE
Add locked favicon to firstrun page

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -142,6 +142,7 @@ export default {
       chunks: ["webextension/firstrun/index"],
       inject: false,
       minify: htmlMinifyOptions,
+      icon: "../icons/lb_locked.svg",
     }),
     new HTMLWebpackPlugin({
       template: "template.ejs",


### PR DESCRIPTION
### Before:

<img width="256" alt="menubar_and_welcome_to_lockbox" src="https://user-images.githubusercontent.com/557895/32666131-591a57ae-c5eb-11e7-990f-709f7045b627.png">

### After:

<img width="292" alt="with_lock" src="https://user-images.githubusercontent.com/557895/32666159-69bc9040-c5eb-11e7-9810-a0cc6be5cb0e.png">

Fixes #309 