### PR TITLE
Set text area focus blue to match input styles

### DIFF
--- a/src/webextension/widgets/text-area.css
+++ b/src/webextension/widgets/text-area.css
@@ -17,7 +17,6 @@
 }
 
 .text-area:focus {
-  /* Note: This is reverse-engineered by looking at the mockups. */
-  border-color: #7cddee;
+  border-color: #0a84ff;
   box-shadow: 0 0 3px rgba(124, 221, 238, 0.5);
 }

--- a/src/webextension/widgets/text-area.css
+++ b/src/webextension/widgets/text-area.css
@@ -18,5 +18,7 @@
 
 .text-area:focus {
   border-color: #0a84ff;
-  box-shadow: 0 0 3px rgba(124, 221, 238, 0.5);
+  /* Note: This is a best-guess from the screenshots for the Photon spec, since
+     the box shadow isn't actually specified. */
+  box-shadow: 0 0 3px rgba(10, 168, 255, 0.5);
 }


### PR DESCRIPTION
Resolves #256 again

<img width="375" alt="screen shot 2017-11-13 at 10 35 47 am" src="https://user-images.githubusercontent.com/49511/32739902-72bb00da-c85e-11e7-8765-e057fbb98ad2.png">


Now the `text area` focus blue color matches the `input` fields. Consistency 👐 