### PR TITLE
Add landing page create button

### DIFF
--- a/src/webextension/locales/en-US/firstrun.ftl
+++ b/src/webextension/locales/en-US/firstrun.ftl
@@ -18,6 +18,8 @@ welcome-feedback =
     button within the tool, including any issues you may find, things
     you like, and the things you're looking forward to in the future.
 
+welcome-add-item = Create Entry
+
 master-password-setup-formtitle = Please create a master password below:
 
 master-password-setup-password = Password

--- a/src/webextension/locales/en-US/firstrun.ftl
+++ b/src/webextension/locales/en-US/firstrun.ftl
@@ -18,8 +18,6 @@ welcome-feedback =
     button within the tool, including any issues you may find, things
     you like, and the things you're looking forward to in the future.
 
-welcome-add-item = Create Entry
-
 master-password-setup-formtitle = Please create a master password below:
 
 master-password-setup-password = Password

--- a/src/webextension/locales/en-US/manage.ftl
+++ b/src/webextension/locales/en-US/manage.ftl
@@ -47,6 +47,8 @@ homepage-greeting =
   including any issues you may find, things you like, and the things you’re
   looking forward to in the future.
 
+homepage-add-entry = Add Entry
+
 item-details-heading-view = Entry Details
 item-details-heading-new = Create a New Entry
 item-details-heading-edit = Edit Entry

--- a/src/webextension/manage/components/homepage.js
+++ b/src/webextension/manage/components/homepage.js
@@ -5,10 +5,20 @@
 import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
+import { connect } from "react-redux";
+
+import Button from "../../widgets/button";
+import { startNewItem } from "../actions";
+import * as telemetry from "../../telemetry";
 
 import styles from "./homepage.css";
 
-export default function Homepage({count}) {
+function Homepage({count, dispatch}) {
+  const doAddItem = () => {
+    telemetry.recordEvent("addClick", "addButton", "homescreenAddButton");
+    dispatch(startNewItem());
+  };
+
   const imgSrc = browser.extension.getURL("/images/lockie_v2.svg");
 
   let title;
@@ -27,10 +37,18 @@ export default function Homepage({count}) {
       <Localized id="homepage-greeting">
         <p>{"yOu'Ve suCCessfuLLY iNSTalled..."}</p>
       </Localized>
+      <Localized id="homepage-add-entry">
+        <Button theme="primary" onClick={doAddItem}>
+          aDd enTry
+        </Button>
+      </Localized>
     </article>
   );
 }
 
 Homepage.propTypes = {
   count: PropTypes.number.isRequired,
+  dispatch: PropTypes.func.isRequired,
 };
+
+export default connect()(Homepage);


### PR DESCRIPTION
This PR adds a button to the landing page for being able to directly add a new entry.

This is meant to start implementing the designs associated with #293.

<img width="1075" alt="screenshot 2017-11-14 01 10 20" src="https://user-images.githubusercontent.com/33464504/32756114-bc3b0884-c8d8-11e7-8ec0-1f77a75e2a7c.png">
