### PR TITLE
Update to more precise and accurate favicon paths

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -144,7 +144,7 @@ export default {
       chunks: ["webextension/firstrun/index"],
       inject: false,
       minify: htmlMinifyOptions,
-      icon: "../icons/lb_locked.svg",
+      icon: "/icons/lb_locked.svg",
     }),
     new HTMLWebpackPlugin({
       template: "template.ejs",
@@ -152,7 +152,7 @@ export default {
       chunks: ["webextension/list/manage/index"],
       inject: false,
       minify: htmlMinifyOptions,
-      icon: "../icons/lb_unlocked.svg",
+      icon: "/icons/lb_unlocked.svg",
     }),
     new HTMLWebpackPlugin({
       template: "template.ejs",


### PR DESCRIPTION
These moved at #338 and so the favicon on the full manage page is missing.

The firstrun happens to be right, but `list/manage` is no longer one-level away from the icons.

Either way, `icons` is now top-level so we can assume that here, I believe.