### PR TITLE
Add instructions on how to run dev builds with a profile

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -55,10 +55,12 @@ Once you have a new profile created (no matter the location), you can tell jpm
 so that any changes (e.g. adding new entries) will be saved:
 
 ```sh
-npm run run -- -p /path/to/profile --no-copy
+npm run run -- -p PROFILE --no-copy
 ```
 
-Now when you run using this new profile, any data or settings you make to the
+The PROFILE value may be a profile name or the path to the profile.
+
+Now, when you run using this profile, any data or settings you make to the
 browser itself or in Lockbox will be available for future runs.
 
 ## Setting npm run flags 
@@ -66,7 +68,7 @@ browser itself or in Lockbox will be available for future runs.
 To specify flags for `run` to use regularly, use `npm config set jpm_runflags`:
 
 ```sh
-npm config set jpm_runflags="-b nightly -p /path/to/profile --no-copy"
+npm config set jpm_runflags="-b nightly -p PROFILE --no-copy"
 ```
 
 This way if you want to always test locally using an existing profile (with

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@ npm install
 To **build the project**, you can run:
 
 ```sh
-npm run-script build
+npm run build
 ```
 
 This puts all the necessary files in the `dist/` directory, which you can then
@@ -24,7 +24,7 @@ temporarily load into Firefox (e.g. `about:debugging`).
 To **build an extension .xpi**, you can run:
 
 ```sh
-npm run-script package
+npm run package
 ```
 
 :warning: The resulting add-on is unsigned and likely won't work on release
@@ -39,7 +39,7 @@ you'll need to flip the `extensions.legacy.enabled` preference, too.
 To **run the extension in a Firefox Nightly** browser, you can run:
 
 ```sh
-npm run-script run -- -b nightly
+npm run run -- -b nightly
 ```
 
 This will automatically create a fresh new user profile that will not persist
@@ -52,10 +52,10 @@ create a new profile by browsing to `about:profiles`.
 
 Once you have a new profile created (no matter the location), you can tell jpm
 (via npm) to run using that profile _and_ not to copy the profile temporarily
-so that any changes (e.g. adding new entries) will be saved and persist:
+so that any changes (e.g. adding new entries) will be saved:
 
 ```sh
-npm run-script run -- -p /path/to/profile --no-copy
+npm run run -- -p /path/to/profile --no-copy
 ```
 
 Now when you run using this new profile, any data or settings you make to the

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,13 +42,35 @@ To **run the extension in a Firefox Nightly** browser, you can run:
 npm run-script run -- -b nightly
 ```
 
+This will automatically create a fresh new user profile that will not persist
+between runs. This means the data will be lost every time.
+
+## Running the extension with a persistent profile
+
+To **run the extension with a profile that persists** between runs, you can
+create a new profile by browsing to `about:profiles`.
+
+Once you have a new profile created (no matter the location), you can tell jpm
+(via npm) to run using that profile _and_ not to copy the profile temporarily
+so that any changes (e.g. adding new entries) will be saved and persist:
+
+```sh
+npm run-script run -- -p /path/to/profile --no-copy
+```
+
+Now when you run using this new profile, any data or settings you make to the
+browser itself or in Lockbox will be available for future runs.
+
+## Setting npm run flags 
+
 To specify flags for `run` to use regularly, use `npm config set jpm_runflags`:
 
 ```sh
-npm config set jpm_runflags="-b nightly"
+npm config set jpm_runflags="-b nightly -p /path/to/profile --no-copy"
 ```
 
-This way you can just run:
+This way if you want to always test locally using an existing profile (with
+example data) using Firefox Nightly, you can just run (without adding flags):
 
 ```sh
 npm run run


### PR DESCRIPTION
Closes #274 by adding instructions on how to create a new profile, add it to your jpm config, and run it so it persists between runs. This way testers and developers can set up dummy data locally instead of having to do it every single time.

I've been doing this for a day or so. I know @linuxwolf said he was doing his own `cp -R` shenanigans to achieve roughly the same effect.

Either way, following these instructions mean my test profile opens with ~dozens of entries pre-loaded.

I know @jimporter also wanted to do #170 (a build config) but I wanted to quickly document this approach for those that want/need a good solution sooner.