### PR TITLE
Disable the filter when there are no items; resolves #324

### DIFF
--- a/src/webextension/list/containers/item-filter.js
+++ b/src/webextension/list/containers/item-filter.js
@@ -20,6 +20,7 @@ function ItemFilter(props) {
 export default connect(
   (state) => ({
     value: state.filter,
+    disabled: state.cache.items.length === 0,
   }),
   (dispatch) => ({
     onChange: (value) => { dispatch(filterItems(value)); },

--- a/src/webextension/list/manage/containers/add-item.js
+++ b/src/webextension/list/manage/containers/add-item.js
@@ -9,17 +9,13 @@ import { connect } from "react-redux";
 
 import Button from "../../../widgets/button";
 import { startNewItem } from "../../actions";
+import { NEW_ITEM_ID } from "../../common";
 import * as telemetry from "../../../telemetry";
 
-function AddItem({dispatch}) {
-  const doClick = () => {
-    telemetry.recordEvent("addClick", "addButton");
-    dispatch(startNewItem());
-  };
-
+function AddItem({disabled, onAddItem}) {
   return (
     <Localized id="toolbar-add-item">
-      <Button theme="primary" onClick={doClick}>
+      <Button theme="primary" disabled={disabled} onClick={onAddItem}>
         aDd iTEm
       </Button>
     </Localized>
@@ -27,7 +23,18 @@ function AddItem({dispatch}) {
 }
 
 AddItem.propTypes = {
-  dispatch: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  onAddItem: PropTypes.func.isRequired,
 };
 
-export default connect()(AddItem);
+export default connect(
+  (state) => ({
+    disabled: state.list.selectedItemId === NEW_ITEM_ID,
+  }),
+  (dispatch) => ({
+    onAddItem: () => {
+      telemetry.recordEvent("addClick", "addButton");
+      dispatch(startNewItem());
+    },
+  })
+)(AddItem);

--- a/src/webextension/widgets/button.css
+++ b/src/webextension/widgets/button.css
@@ -8,6 +8,19 @@
   border: 0;
 }
 
+.button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.button:focus {
+  box-shadow: inset 0 0 0 2px #0a84ff, 0 0 0 3px rgba(10, 132, 255, 0.3);
+}
+
+.button::-moz-focus-inner {
+  border: none;
+}
+
 .primary-theme {
   color: #ffffff;
   background-color: #0060df;
@@ -23,21 +36,21 @@
   background-color: transparent;
 }
 
-.primary-theme:hover {
+.primary-theme:not([disabled]):hover {
   background-color: #003eaa;
 }
 
-.normal-theme:hover,
-.ghost-theme:hover {
+.normal-theme:not([disabled]):hover,
+.ghost-theme:not([disabled]):hover {
   background-color: rgba(12, 12, 13, 0.2);
 }
 
-.primary-theme:active {
+.primary-theme:not([disabled]):active:hover {
   background-color: #002275;
 }
 
-.normal-theme:hover,
-.ghost-theme:hover {
+.normal-theme:not([disabled]):active:hover,
+.ghost-theme:not([disabled]):active:hover {
   background-color: rgba(12, 12, 13, 0.3);
 }
 

--- a/src/webextension/widgets/filter-input.js
+++ b/src/webextension/widgets/filter-input.js
@@ -14,6 +14,7 @@ export default class FilterInput extends React.Component {
       className: PropTypes.string,
       onChange: PropTypes.func,
       value: PropTypes.string,
+      disabled: PropTypes.bool,
     };
   }
 
@@ -21,6 +22,7 @@ export default class FilterInput extends React.Component {
     return {
       className: "",
       value: "",
+      disabled: false,
     };
   }
 
@@ -43,15 +45,20 @@ export default class FilterInput extends React.Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const {className, onChange, value, ...props} = this.props;
-    const finalClassName = `${styles.inputWrapper} ${className}`.trimRight();
+    const {className, onChange, value, disabled, ...props} = this.props;
+    const disabledClass = disabled ? ` ${styles.disabled}` : "";
+    const finalClassName = (
+      `${styles.inputWrapper}${disabledClass} ${className}`
+    ).trimRight();
 
     return (
       <div className={finalClassName}>
-        <input type="search" {...props} value={this.state.value}
+        <input type="search" {...props} disabled={disabled}
+               value={this.state.value}
                onChange={(e) => this.updateValue(e.target.value)}/>
         <Localized id="filter-input-clear">
-          <button type="button" onClick={() => this.updateValue("")}>
+          <button type="button" disabled={disabled}
+                  onClick={() => this.updateValue("")}>
             cLEAr
           </button>
         </Localized>

--- a/src/webextension/widgets/input.css
+++ b/src/webextension/widgets/input.css
@@ -21,22 +21,28 @@
   border-radius: 2px;
 }
 
+.input[disabled],
+.input-wrapper.disabled {
+  background-color: #ededf0;
+  cursor: not-allowed;
+}
+
 .input {
   padding: 0 8px;
   font-size: 13px;
 }
 
-.input:hover,
-.input-wrapper:hover {
+.input:not([disabled]):hover,
+.input-wrapper:not(.disabled):hover {
   border-color: rgba(12, 12, 13, 0.5);
 }
 
 .input:focus,
 .input-wrapper:focus-within {
   border-color: #0a84ff;
-  /* Note: This is a best-guess from the screenshots for the Photon spec, since
-     the box shadow isn't actually specified. */
-  box-shadow: 0 0 3px rgba(10, 168, 255, 0.5);
+  /* Note: This is adapted from the Photon button spec, since the input fields
+     spec doesn't define this. */
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.3);
 }
 
 .input-wrapper {
@@ -51,6 +57,10 @@
   min-width: 0;
   border: 0;
   background-color: transparent;
+}
+
+.input-wrapper.disabled > input {
+  cursor: not-allowed;
 }
 
 .input-wrapper button {

--- a/src/webextension/widgets/password-input.js
+++ b/src/webextension/widgets/password-input.js
@@ -15,6 +15,7 @@ export default class PasswordInput extends React.Component {
     return {
       className: PropTypes.string,
       monospace: PropTypes.bool,
+      disabled: PropTypes.bool,
     };
   }
 
@@ -22,6 +23,7 @@ export default class PasswordInput extends React.Component {
     return {
       className: "",
       monospace: true,
+      disabled: false,
     };
   }
 
@@ -48,20 +50,24 @@ export default class PasswordInput extends React.Component {
   }
 
   render() {
-    const {className, monospace, ...props} = this.props;
-    const finalClassName = `${styles.inputWrapper} ${className}`.trimRight();
+    const {className, monospace, disabled, ...props} = this.props;
+    const disabledClass = disabled ? ` ${styles.disabled}` : "";
+    const finalClassName = (
+      `${styles.inputWrapper}${disabledClass} ${className}`
+    ).trimRight();
+
     return (
       <div className={finalClassName}>
-        <input className={monospace ? styles.monospace : ""}
+        <input className={monospace ? styles.monospace : ""} disabled={disabled}
                type={this.state.showPassword ? "text" : "password"}
                ref={(element) => this.inputElement = element} {...props}/>
         <ButtonStack ref={(element) => this.stackElement = element}>
           <Localized id="password-input-show">
-            <button type="button"
+            <button type="button" disabled={disabled}
                     onClick={() => this.showPassword(true)}>sHOw</button>
           </Localized>
           <Localized id="password-input-hide">
-            <button type="button"
+            <button type="button" disabled={disabled}
                     onClick={() => this.showPassword(false)}>hIDe</button>
           </Localized>
         </ButtonStack>

--- a/test/list/containers/item-filter-test.js
+++ b/test/list/containers/item-filter-test.js
@@ -10,7 +10,7 @@ import thunk from "redux-thunk";
 
 import { simulateTyping } from "test/common";
 import mountWithL10n from "test/mocks/l10n";
-import { initialState } from "../manage/mock-redux-state";
+import { filledState } from "../manage/mock-redux-state";
 import { FILTER_ITEMS } from "src/webextension/list/actions";
 import ItemFilter from "src/webextension/list/containers/item-filter";
 
@@ -21,7 +21,7 @@ describe("list > containers > <ItemFilter/>", () => {
   let store, wrapper;
 
   beforeEach(() => {
-    store = mockStore(initialState);
+    store = mockStore(filledState);
     wrapper = mountWithL10n(
       <Provider store={store}>
         <ItemFilter/>

--- a/test/list/manage/containers/add-item-test.js
+++ b/test/list/manage/containers/add-item-test.js
@@ -10,6 +10,7 @@ import { Provider } from "react-redux";
 import { initialState } from "../mock-redux-state";
 import mountWithL10n from "test/mocks/l10n";
 import { startNewItem } from "src/webextension/list/actions";
+import { NEW_ITEM_ID } from "src/webextension/list/common";
 import AddItem from "src/webextension/list/manage/containers/add-item";
 
 const middlewares = [];
@@ -25,5 +26,22 @@ describe("list > manage > containers > <AddItem/>", () => {
     );
     wrapper.simulate("click");
     expect(store.getActions()).to.deep.equal([startNewItem()]);
+  });
+
+  it("disabled when editing a new item", () => {
+    const store = mockStore({
+      ...initialState,
+      list: {
+        ...initialState.list,
+        selectedItemId: NEW_ITEM_ID,
+      },
+    });
+    const wrapper = mountWithL10n(
+      <Provider store={store}>
+        <AddItem/>
+      </Provider>
+    );
+    wrapper.simulate("click");
+    expect(store.getActions()).to.deep.equal([]);
   });
 });

--- a/test/widgets/filter-input-test.js
+++ b/test/widgets/filter-input-test.js
@@ -24,6 +24,17 @@ describe("widgets > <FilterInput/>", () => {
     );
   });
 
+  it("render disabled input", () => {
+    const wrapper = mountWithL10n(
+      <FilterInput value="some text" disabled={true}/>
+    );
+    expect(wrapper.find("input")).to.have.prop("disabled", true);
+    expect(wrapper.find("button")).to.have.prop("disabled", true);
+    expect(wrapper.childAt(0).prop("className")).to.match(
+      /^\S+input-wrapper\S+ \S+disabled\S+$/
+    );
+  });
+
   it("merge classNames", () => {
     const wrapper = mountWithL10n(
       <FilterInput className="foo" value="some text"/>


### PR DESCRIPTION
Here's a quick version of disabling the filter when there are no items. No tests yet; I just wanted to see what people think of the UX, since the Photon specs don't appear to have anything about what disabled form fields should look like. We could also add a different placeholder string if we want, e.g. "Add some entries before filtering them" (that's terrible wording, but you get the idea).

- [x] Disable search filter input / clear when no items exist
- [x] CSS for disabled button states for both primary (blue) and secondary (grey) buttons
- [ ] Disabled "Home" button when not on a item detail (create, edit, view) view (aka can't click "Home" when home)
- [x] Disable button for "New Entry" while actually creating a current entry
- [ ] Disable "Save Entry" until at least one field has been populated