### PR TITLE
Remove empty "API Guide" from mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,5 @@ pages:
 - 'Release Notes': 'release-notes.md'
 - 'Contributing': 'contributing.md'
 - 'Code of Conduct': 'code_of_conduct.md'
-- 'API Guide': 'api.md'
 - 'Metrics Guide': 'metrics.md'
 - 'Releases': 'releases.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,5 @@ pages:
 - 'User Guide': 'user-guide.md'
 - 'Release Notes': 'release-notes.md'
 - 'Contributing': 'contributing.md'
-- 'Code of Conduct': 'code_of_conduct.md'
 - 'Metrics Guide': 'metrics.md'
 - 'Releases': 'releases.md'


### PR DESCRIPTION
Fixes #366 
Depends on #51 (once populated, we should add it back)