### PR TITLE
add integration test script runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "run": "jpm run --addon-dir dist/ ${npm_config_jpm_runflags} --prefs jpm-prefs.json",
     "pretest": "npm run-script autolint",
     "test": "cross-env NODE_ENV=test karma start",
+    "preintegration": "cross-env ENABLE_DOORHANGER=1 npm run package",
+    "integration": "tox -r",
     "nsp": "nsp check",
     "codecov": "codecov",
     "clean": "git clean -fX ./dist ./*.xpi ./addon.env && npm run :clean:doc ",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "run": "jpm run --addon-dir dist/ ${npm_config_jpm_runflags} --prefs jpm-prefs.json",
     "pretest": "npm run-script autolint",
     "test": "cross-env NODE_ENV=test karma start",
-    "preintegration": "cross-env ENABLE_DOORHANGER=1 npm run package",
+    "preintegration": "npm run package",
     "integration": "tox -r",
     "nsp": "nsp check",
     "codecov": "codecov",


### PR DESCRIPTION
Adds "integration" to the package.json scripts, in order to run `tox`-based integration tests, with prerequisites.