### PR TITLE
Minor fixes before release

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ here](feedback-link).
    ![sinup for fxa](./images/tour-04.signup-fxa.png)
 
 _This is just one component of the Lockbox product. Please see the [Lockbox
-website](website-link) for more documentation and context._
+website][website-link] for more documentation and context._
 
 [install-link]: https://testpilot.firefox.com/files/lockbox@mozilla.com/latest
 [faq-link]: /faqs/

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -144,7 +144,7 @@ All events are currently implemented under the **category: lockboxV0**. The `ext
 
 9. `feedbackClick` fires when the user clicks the "Send Feedback" button. **objects**: manage
 
-10. `faqClick` fires when the user clicks the "FAQs" button. **objects**: manage
+10. `faqClick` fires when the user clicks the "FAQ" button. **objects**: manage
 
 11. `resetRequested` fires when the user clicks the "Reset" button in the Lockbox settings. **objects**: settings
 

--- a/src/webextension/firstrun/components/intro.js
+++ b/src/webextension/firstrun/components/intro.js
@@ -16,10 +16,6 @@ export default function Intro() {
       <Localized id="firstrun-intro-tagline">
         <h2>mORe wELCOMe</h2>
       </Localized>
-      <Localized id="firstrun-intro-warning">
-        <p>Lorem ipsum dolor sit amet, consectetur. Mauris, aliquam vel
-        pellentesque et, mattis bibendum tellus. Fusce sodales.</p>
-      </Localized>
     </section>
   );
 }

--- a/src/webextension/list/manage/components/account-linked.css
+++ b/src/webextension/list/manage/components/account-linked.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .linked {
-  margin: 2em 0;
+  margin: 2em auto;
   padding: 0;
   display: flex;
   flex-flow: column nowrap;

--- a/src/webextension/list/manage/components/link-account.css
+++ b/src/webextension/list/manage/components/link-account.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 2em 0;
+  margin: 2em auto;
   padding: 0;
   max-width: 500px;
 }

--- a/src/webextension/list/manage/containers/open-faq.css
+++ b/src/webextension/list/manage/containers/open-faq.css
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.faq {
+  font-size: 15px;
+}

--- a/src/webextension/list/manage/containers/open-faq.js
+++ b/src/webextension/list/manage/containers/open-faq.js
@@ -14,7 +14,7 @@ function OpenFAQ({onOpenFAQ}) {
   return (
     <Localized id="toolbar-open-faq">
       <ExternalLink onClick={onOpenFAQ}>
-        fAQs
+        fAq
       </ExternalLink>
     </Localized>
   );

--- a/src/webextension/list/manage/containers/open-faq.js
+++ b/src/webextension/list/manage/containers/open-faq.js
@@ -10,10 +10,12 @@ import { connect } from "react-redux";
 import { ExternalLink } from "../../../widgets/link";
 import { openFAQ } from "../../actions";
 
+import styles from "./open-faq.css";
+
 function OpenFAQ({onOpenFAQ}) {
   return (
     <Localized id="toolbar-open-faq">
-      <ExternalLink onClick={onOpenFAQ}>
+      <ExternalLink className={styles.faq} onClick={onOpenFAQ}>
         fAq
       </ExternalLink>
     </Localized>

--- a/src/webextension/locales/en-US/firstrun.ftl
+++ b/src/webextension/locales/en-US/firstrun.ftl
@@ -4,10 +4,6 @@ document
 firstrun-intro-title = Welcome to { product-title }
 firstrun-intro-tagline = { product-tagline }
 
-firstrun-intro-warning =
-    This is a rapidly evolving prototype that will change as Alpha progresses.
-    Any data stored here is not guaranteed to be retained in future updates.
-
 firstrun-using-guest-title = New to Lockbox?
 
 firstrun-using-guest-action = Get Started

--- a/src/webextension/locales/en-US/list.ftl
+++ b/src/webextension/locales/en-US/list.ftl
@@ -49,17 +49,17 @@ all-items-filtered = No results
 intro-page-step-1 =
   Save username and password info to create a { product-title } entry.
 
-  .title = Add Login Info to { product-title }
+  .title = Add login info to { product-title }
 
 intro-page-step-2 =
   Click the { product-title } icon to see all the entries you've saved.
 
-  .title = Go Straight to Your Logins
+  .title = Go straight to your logins
 
 intro-page-step-3 =
   Copy an entry's info to sign in right from Firefox.
 
-  .title = Sign in From { product-title }
+  .title = Sign in from { product-title }
 
 homepage-title = { product-tagline }
 

--- a/src/webextension/locales/en-US/list.ftl
+++ b/src/webextension/locales/en-US/list.ftl
@@ -39,7 +39,7 @@ item-filter
 toolbar-add-item = New entry
 toolbar-go-home = Home
 toolbar-send-feedback = Provide Feedback
-toolbar-open-faq = FAQs
+toolbar-open-faq = FAQ
 
 all-items-empty =
   When you add an Entry, it automatically shows up here.

--- a/src/webextension/widgets/toolbar.css
+++ b/src/webextension/widgets/toolbar.css
@@ -10,7 +10,7 @@
 }
 
 .toolbar > * + * {
-  margin-inline-start: 1ch;
+  margin-inline-start: 2ch;
 }
 
 .toolbar-space {

--- a/test/integration/pages/base.py
+++ b/test/integration/pages/base.py
@@ -9,7 +9,7 @@ class Base(Page):
     def __init__(self, selenium, base_url, **kwargs):
         """Create the base class object."""
         super(Base, self).__init__(
-            selenium, base_url, timeout=10, **kwargs)
+            selenium, base_url, timeout=30, **kwargs)
 
     def fxa_sign_in(self, user, password):
         """Sign in to fxa."""


### PR DESCRIPTION
This is a quick branch with minor fixes from another "once over".

#### FAQs link size and copy text updated, with a little more spacing in the nav bar

<img width="401" alt="lockbox_entries" src="https://user-images.githubusercontent.com/49511/33947810-fe82f44e-dfea-11e7-9869-9422b7200b93.png">

#### No more warning about data loss on the welcome screen

<img width="690" alt="welcome_to_lockbox" src="https://user-images.githubusercontent.com/49511/33948011-7948c154-dfeb-11e7-9c17-a59999cf0291.png">


#### Fixed centering on the intro page in all FxA cases

<img width="1111" alt="lockbox_entries" src="https://user-images.githubusercontent.com/49511/33948015-7cc8b83e-dfeb-11e7-95b1-853940d1d2b4.png">

