### PR TITLE
Fix feedback link on docs/index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ security.
 
 Install it and sign in with your Firefox Account to encrypt your data with
 tamper-resistant block cipher technology. Then [share feedback
-here](feedback-link).
+here][feedback-link].
 
 ## Get Started
 


### PR DESCRIPTION
This was causing a 404 on the https://mozilla-lockbox.github.io/lockbox-extension/ site which was causing a bunch of other odd results from my link checker.
