### PR TITLE
Added error handling to class name munger.

### DIFF
--- a/test/integration/pages/home.py
+++ b/test/integration/pages/home.py
@@ -17,7 +17,8 @@ class Home(Base):
                             munged_class_name('item-summary')))
     _delete_entry_locator = (By.CSS_SELECTOR,
                              'article div menu '
-                             'button.{}'.format(munged_class_name('normal')))
+                             'button.{}'.format(munged_class_name(
+                                                'normal-theme')))
     _delete_entry_modal_locator = (By.CSS_SELECTOR,
                                    '.ReactModal__Content--after-open '
                                    'menu button.{}'.format(

--- a/test/integration/pages/util/util.py
+++ b/test/integration/pages/util/util.py
@@ -64,3 +64,6 @@ def munged_class_name(name):
                     name + '___' +
                     s[:5]
                 )
+    # If function does not return that means the requested class does not exist
+    # within the dictionary.
+    raise ValueError('Class named {} does not exist.'.format(name))


### PR DESCRIPTION
Fixes: #398

I have the ```munged_class_name``` function throw a ```ValueError``` if the requested class name is not found in the dictionary.

In doing this I found an incorrectly named class so I fixed that too.