### PR TITLE
Don't fire an onChange event from <ScrollingList/> if the new item is already selected

### DIFF
--- a/src/webextension/widgets/scrolling-list.js
+++ b/src/webextension/widgets/scrolling-list.js
@@ -73,8 +73,14 @@ export default class ScrollingList extends React.Component {
     e.preventDefault();
   }
 
-  handleMouseDown(id) {
-    this.props.onChange(id);
+  handleMouseDown(e, id) {
+    if (e.button !== 0) {
+      return;
+    }
+
+    if (this.props.selected !== id) {
+      this.props.onChange(id);
+    }
     if (this.props.onClick) {
       this.props.onClick(id);
     }
@@ -117,7 +123,7 @@ export default class ScrollingList extends React.Component {
           onKeyDown={(e) => this.handleKeyDown(e)}>
         {data.map((item) => {
           let props = {
-            onMouseDown: () => this.handleMouseDown(item.id),
+            onMouseDown: (e) => this.handleMouseDown(e, item.id),
             className: itemClassName,
           };
           if (item.id === selected) {

--- a/test/unit/list/components/item-list-test.js
+++ b/test/unit/list/components/item-list-test.js
@@ -41,8 +41,8 @@ describe("list > components > <ItemList/>", () => {
   });
 
   it("onChange() and onClick() called", () => {
-    wrapper.find(ItemSummary).at(0).simulate("mousedown");
-    expect(onChange).to.have.been.calledWith(items[0].id);
-    expect(onClick).to.have.been.calledWith(items[0].id);
+    wrapper.find(ItemSummary).at(1).simulate("mousedown", {button: 0});
+    expect(onChange).to.have.been.calledWith(items[1].id);
+    expect(onClick).to.have.been.calledWith(items[1].id);
   });
 });

--- a/test/unit/list/manage/containers/all-items-test.js
+++ b/test/unit/list/manage/containers/all-items-test.js
@@ -72,7 +72,7 @@ describe("list > manage > containers > <AllItems/>", () => {
     });
 
     it("selectItem() dispatched", () => {
-      wrapper.find(ItemSummary).at(0).simulate("mousedown");
+      wrapper.find(ItemSummary).at(0).simulate("mousedown", {button: 0});
       expect(store.getActions()[0].type).to.equal(SELECT_ITEM_STARTING);
     });
   });

--- a/test/unit/list/popup/containers/all-items-test.js
+++ b/test/unit/list/popup/containers/all-items-test.js
@@ -65,7 +65,7 @@ describe("list > popup > containers > <AllItems/>", () => {
     });
 
     it("selectItem() dispatched", () => {
-      wrapper.find(ItemSummary).at(0).simulate("mousedown");
+      wrapper.find(ItemSummary).at(0).simulate("mousedown", {button: 0});
       expect(store.getActions()[0].type).to.equal(SELECT_ITEM_STARTING);
     });
   });

--- a/test/unit/widgets/scrolling-list-test.js
+++ b/test/unit/widgets/scrolling-list-test.js
@@ -75,7 +75,7 @@ describe("widgets > <ScrollingList/>", () => {
         expect(onClick).to.have.callCount(0);
       });
 
-      it("not dispatched on spce", () => {
+      it("not dispatched on space", () => {
         wrapper.simulate("keydown", {key: "Space"});
         expect(onClick).to.have.callCount(0);
       });
@@ -100,8 +100,19 @@ describe("widgets > <ScrollingList/>", () => {
 
     describe("onChange()", () => {
       it("dispatched on clicking item", () => {
-        wrapper.find("li").first().simulate("mousedown");
+        wrapper.find("li").first().simulate("mousedown", {button: 0});
         expect(onChange).to.have.been.calledWith("1");
+      });
+
+      it("not dispatched on clicking selected item", () => {
+        wrapper.setProps({selected: "1"});
+        wrapper.find("li").first().simulate("mousedown", {button: 0});
+        expect(onChange).to.have.callCount(0);
+      });
+
+      it("not dispatched on right-clicking item", () => {
+        wrapper.find("li").first().simulate("mousedown", {button: 1});
+        expect(onChange).to.have.callCount(0);
       });
 
       it("dispatched on arrow down", () => {
@@ -146,7 +157,13 @@ describe("widgets > <ScrollingList/>", () => {
 
     describe("onClick()", () => {
       it("dispatched on clicking item", () => {
-        wrapper.find("li").first().simulate("mousedown");
+        wrapper.find("li").first().simulate("mousedown", {button: 0});
+        expect(onClick).to.have.been.calledWith("1");
+      });
+
+      it("dispatched on clicking selected item", () => {
+        wrapper.setProps({selected: "1"});
+        wrapper.find("li").first().simulate("mousedown", {button: 0});
         expect(onClick).to.have.been.calledWith("1");
       });
 


### PR DESCRIPTION
This resolves - in a roundabout way - an issue with clicking the "new item" placeholder entry in the item list causing the editor widget to go away. It resolves a comment in #414.

Also note: this fixes the bug, but this was caused by a few bugs working together to screw everything up. The code for our Redux reducers is badong and I want to fix it (see #297).

![Killing is Badong](https://i.imgur.com/K4HuXI1.gif)