### PR TITLE
Improve selected/focus state for the item list; resolves #414

### DIFF
--- a/src/webextension/list/components/item-list.css
+++ b/src/webextension/list/components/item-list.css
@@ -16,8 +16,8 @@
 }
 
 .item {
-  border-bottom: solid 0.5px #d7d7db;
-  border-right: solid 0.5px #d7d7db;
+  color: #0c0c0d;
+  border-bottom: 1px solid #d7d7db;
 }
 
 .item:nth-child(2n+1) {

--- a/src/webextension/list/components/item-list.js
+++ b/src/webextension/list/components/item-list.js
@@ -10,9 +10,10 @@ import ScrollingList from "../../widgets/scrolling-list";
 
 import styles from "./item-list.css";
 
-export default function ItemList({items, ...props}) {
+export default function ItemList({items, itemClassName, ...props}) {
+  const finalItemClassName = `${styles.item} ${itemClassName}`.trimRight();
   return (
-    <ScrollingList itemClassName={styles.item} data={items} {...props}>
+    <ScrollingList itemClassName={finalItemClassName} data={items} {...props}>
       {({id, title, username}) => {
         return (
           <ItemSummary id={id} title={title} username={username}/>
@@ -30,6 +31,11 @@ ItemList.propTypes = {
       username: PropTypes.string.isRequired,
     }).isRequired
   ).isRequired,
+  itemClassName: PropTypes.string,
+};
+
+ItemList.defaultProps = {
+  itemClassName: "",
 };
 
 export function ItemListPlaceholder({children}) {

--- a/src/webextension/list/components/item-summary.css
+++ b/src/webextension/list/components/item-summary.css
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .item-summary {
-  border-bottom: 1px solid #d7d7db;
   padding: .5em;
   font-size: 15px;
 }
@@ -26,7 +25,6 @@
 .title, .subtitle {
   line-height: 1.5;
   letter-spacing: 0.2px;
-  color: #0c0c0d;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/webextension/list/manage/containers/all-items.css
+++ b/src/webextension/list/manage/containers/all-items.css
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.all-items {
+  border-inline-end: 1px solid #d7d7db;
+}
+
+.all-items > .item[data-selected] {
+  background-color: #b1b1b3;
+}
+
+.all-items:focus > .item[data-selected] {
+  box-shadow: inset 0 0 0 2px #0a84ff;
+}
+

--- a/src/webextension/list/manage/containers/all-items.js
+++ b/src/webextension/list/manage/containers/all-items.js
@@ -14,6 +14,8 @@ import ItemList, { ItemListPlaceholder } from "../../components/item-list";
 
 const collator = new Intl.Collator();
 
+import styles from "./all-items.css";
+
 function AllItems({totalItemCount, ...props}) {
   if (props.items.length === 0) {
     return (
@@ -24,7 +26,10 @@ function AllItems({totalItemCount, ...props}) {
       </Localized>
     );
   }
-  return <ItemList {...props}/>;
+  return (
+    <ItemList styledItems={false} className={styles.allItems}
+              itemClassName={styles.item} {...props}/>
+  );
 }
 
 AllItems.propTypes = {

--- a/src/webextension/widgets/scrolling-list.css
+++ b/src/webextension/widgets/scrolling-list.css
@@ -14,17 +14,16 @@
   outline-style: none;
 }
 
-.scrolling-list > li[data-selected] {
+.styled-item {
   color: #0c0c0d;
   background-color: #f9f9fa;
-  border-right: none;
 }
 
-.scrolling-list:focus > li[data-selected] {
+.scrolling-list > .styled-item[data-selected] {
+  background-color: #b1b1b3;
+}
+
+.scrolling-list:focus > .styled-item[data-selected] {
   color: #ffffff;
   background-color: #0060df;
-}
-
-.scrolling-list > li[data-selected=false] {
-  border-right: #ff0000;
 }

--- a/src/webextension/widgets/scrolling-list.js
+++ b/src/webextension/widgets/scrolling-list.js
@@ -12,6 +12,7 @@ export default class ScrollingList extends React.Component {
     return {
       className: PropTypes.string,
       itemClassName: PropTypes.string,
+      styledItems: PropTypes.boolean,
       children: PropTypes.func.isRequired,
       data: PropTypes.arrayOf(
         PropTypes.shape({
@@ -29,6 +30,7 @@ export default class ScrollingList extends React.Component {
     return {
       className: "",
       itemClassName: "",
+      styledItems: true,
       tabIndex: "0",
       selected: null,
     };
@@ -112,10 +114,12 @@ export default class ScrollingList extends React.Component {
   }
 
   render() {
-    const { className, itemClassName, children, data, tabIndex,
+    const { className, itemClassName, styledItems, children, data, tabIndex,
             selected } = this.props;
-    const finalClassName = `${styles.scrollingList} ${className}`
-                           .trimRight();
+    const finalClassName = `${styles.scrollingList} ${className}`.trimRight();
+    const finalItemClassName = styledItems ?
+          `${styles.styledItem} ${itemClassName}`.trimRight() :
+          itemClassName;
 
     return (
       <ul tabIndex={tabIndex} className={finalClassName}
@@ -124,7 +128,7 @@ export default class ScrollingList extends React.Component {
         {data.map((item) => {
           let props = {
             onMouseDown: (e) => this.handleMouseDown(e, item.id),
-            className: itemClassName,
+            className: finalItemClassName,
           };
           if (item.id === selected) {
             Object.assign(props, {


### PR DESCRIPTION
This improves the styling for the item list, especially where the styles are defined. Notable bits:

* `border-right` (now `border-inline-end` for RTL support) is only defined for the management UI, so it won't hurt the doorhanger
* Right border is now always shown, since the "no right border" thing didn't work great when we had a scrollbar. (Todo: we should probably talk to the Photon design team about whether overlay scrollbars should be a Photon thing.)
* Borders are 1px now (Zeplin shows them as 0.5px, but that's because it's a border on all sides, and we just do bottom/right.
* Focus state is improved, and should follow @changecourse's visual suggestions. We can (possibly should) continue to look at this to decide what we can do to improve it further.