### PR TITLE
Release docs update

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,7 @@
 
 ## 0.1.4-alpha
 
-_Date: 2017-12-11_
+_Date: 2017-12-13_
 
 ### What's New
 
@@ -11,9 +11,6 @@ _Date: 2017-12-11_
 - See the visual design and polish come together for the entire experience ([#351](https://github.com/mozilla-lockbox/lockbox-extension/pull/351))
 - Get help and instructions when you first get started ([#392](https://github.com/mozilla-lockbox/lockbox-extension/issues/392))
 - Get additional support from the updated [Lockbox website](https://mozilla-lockbox.github.io/lockbox-extension/), including the FAQ ([#345](https://github.com/mozilla-lockbox/lockbox-extension/issues/345))
-
-
-### What's Fixed
 
 ### Known Issues
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -34,7 +34,7 @@ To generate the next release binary:
     - Open the pull request so we can show the changes, CI status, and approvals
       - Request an approval from the P.I. and Product representatives
     - Once the release has been reviewed, tested, and approved to go live, merge and close the pull request
-    - Test Pilot's Jenkins will then build, sign and deploy the extension (see ["Extension Signing"](#extension-signing))
+    - Test Pilot's Jenkins will then build, sign, and deploy the extension (see ["Extension Signing"](#extension-signing))
 4. Tag the latest commit on `production` branch with an annotated version and push the tag:
     - `git tag -a -m "Release 0.1.0" 0.1.0`
     - `git push upstream 0.1.0`
@@ -45,9 +45,6 @@ To generate the next release binary:
     - Download the signed add-on: `wget -O signed-addon.xpi https://testpilot.firefox.com/files/lockbox@mozilla.com/latest`
     - Attach to the GitHub Release the downloaded signed add-on
 8. Send an announcement to the team (e.g., via Slack team channel)
-
-[production-compare]: https://github.com/mozilla-lockbox/lockbox-extension/compare/production...master
-[releases]: https://github.com/mozilla-lockbox/lockbox-extension/releases
 
 ## Extension Signing
 
@@ -64,3 +61,6 @@ The resulting files deployed are:
 - Latest version of the signed extension XPI: [https://testpilot.firefox.com/files/lockbox@mozilla.com/latest](https://testpilot.firefox.com/files/lockbox@mozilla.com/latest)
 
 **IMPORTANT:** Test Pilot reports the status of build, signing, and deployment of its artifacts on the IRC channel **#testpilot-bots**.  Be sure to join the channel prior to pushing the `production` branch to GitHub in order to receive the status updates.
+
+[production-compare]: https://github.com/mozilla-lockbox/lockbox-extension/compare/production...master
+[releases]: https://github.com/mozilla-lockbox/lockbox-extension/releases

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,14 +30,10 @@ To generate the next release binary:
     - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"
     - consult with Product Management on wording if needed
 2. Commit and ultimately merge to `master` branch
-3. Merge the `master` branch into `production` branch and push to GitHub:
-    - `git checkout master`
-    - `git pull upstream master` (to make sure you have the latest)
-    - `git checkout production`
-    - `git pull upstream production` (to make sure you have the latest)
-    - `git merge master`
-    - `git push upstream production`
-    - Test Pilot's Jenkins will now build and sign the extension (see ["Extension Signing"](#extension-signing))
+3. Create a pull request comparing the `master` branch and `production` branch on GitHub
+    - Open the pull request so we can show the changes, CI status, and approvals
+    - Once the release has been reviewed, tested, and approved to go live, merge and close the pull request
+    - Test Pilot's Jenkins will then build and sign the extension (see ["Extension Signing"](#extension-signing))
 4. Tag the latest commit on `production` branch with an annotated version and push the tag:
     - `git tag -a -m "Release 0.1.0" 0.1.0`
     - `git push upstream 0.1.0`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -34,19 +34,20 @@ To generate the next release binary:
     - Open the pull request so we can show the changes, CI status, and approvals
       - Request an approval from the P.I. and Product representatives
     - Once the release has been reviewed, tested, and approved to go live, merge and close the pull request
-    - Test Pilot's Jenkins will then build and sign the extension (see ["Extension Signing"](#extension-signing))
+    - Test Pilot's Jenkins will then build, sign and deploy the extension (see ["Extension Signing"](#extension-signing))
 4. Tag the latest commit on `production` branch with an annotated version and push the tag:
     - `git tag -a -m "Release 0.1.0" 0.1.0`
     - `git push upstream 0.1.0`
-    - Travis-CI will build and generate a GitHub Release
+    - Travis-CI will build and generate a [GitHub Release][releases]
 7. Edit the resulting GitHub Release
-    - Set the GitHub Release title to match the version
+    - Set the [GitHub Release][releases] title to match the version
     - Set the GitHub Release notes to match the `docs/release-notes.md`
     - Download the signed add-on: `wget -O signed-addon.xpi https://testpilot.firefox.com/files/lockbox@mozilla.com/latest`
     - Attach to the GitHub Release the downloaded signed add-on
 8. Send an announcement to the team (e.g., via Slack team channel)
 
 [production-compare]: https://github.com/mozilla-lockbox/lockbox-extension/compare/production...master
+[releases]: https://github.com/mozilla-lockbox/lockbox-extension/releases
 
 ## Extension Signing
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,7 +30,7 @@ To generate the next release binary:
     - each release includes the sub headings "What's New", "What's Fixed", and "Known Issues"
     - consult with Product Management on wording if needed
 2. Commit and ultimately merge to `master` branch
-3. Create a pull request comparing the `master` branch and `production` branch on GitHub
+3. Create a pull request on GitHub [comparing changes from the `master` branch against/to `production`][production-compare]
     - Open the pull request so we can show the changes, CI status, and approvals
     - Once the release has been reviewed, tested, and approved to go live, merge and close the pull request
     - Test Pilot's Jenkins will then build and sign the extension (see ["Extension Signing"](#extension-signing))
@@ -45,6 +45,7 @@ To generate the next release binary:
     - Attach to the GitHub Release the downloaded signed add-on
 8. Send an announcement to the team (e.g., via Slack team channel)
 
+[production-compare]: https://github.com/mozilla-lockbox/lockbox-extension/compare/production...master
 
 ## Extension Signing
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -32,6 +32,7 @@ To generate the next release binary:
 2. Commit and ultimately merge to `master` branch
 3. Create a pull request on GitHub [comparing changes from the `master` branch against/to `production`][production-compare]
     - Open the pull request so we can show the changes, CI status, and approvals
+      - Request an approval from the P.I. and Product representatives
     - Once the release has been reviewed, tested, and approved to go live, merge and close the pull request
     - Test Pilot's Jenkins will then build and sign the extension (see ["Extension Signing"](#extension-signing))
 4. Tag the latest commit on `production` branch with an annotated version and push the tag:


### PR DESCRIPTION
I hadn't finished publishing the update to the release process wherein we create a PR for a release (comparing `production` ◀️ `master`) such as the one here: https://github.com/mozilla-lockbox/lockbox-extension/pull/408

This update captures the step. @linuxwolf @jimporter for future releases is this instruction clear? Anything to add or change before merging?