### PR TITLE
Allow running integration tests on Python 3.* instead of just 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36-integration-tests, flake8
+envlist = py3-integration-tests, flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Resolves #420