### PR TITLE
explicitly use guest-mode app key

### DIFF
--- a/src/webextension/background/browser-action.js
+++ b/src/webextension/background/browser-action.js
@@ -4,6 +4,7 @@
 
 import { openView } from "./views";
 import getAccount, * as accounts from "./accounts";
+import { DEFAULT_APP_KEY } from "./datastore";
 import * as telemetry from "./telemetry";
 
 let listener;
@@ -59,7 +60,7 @@ export default async function updateBrowserAction({account = getAccount(), datas
     if (account.mode === accounts.GUEST) {
       // unlock on user's behalf ...
       // XXXX: is this a bad idea or terrible idea?
-      await datastore.unlock();
+      await datastore.unlock(DEFAULT_APP_KEY);
       return installEntriesAction();
     }
     // setup unlock popup

--- a/src/webextension/background/datastore.js
+++ b/src/webextension/background/datastore.js
@@ -20,6 +20,12 @@ async function recordMetric(method, itemid, fields) {
   telemetry.recordEvent(method, "datastore", extra);
 }
 
+export const DEFAULT_APP_KEY = {
+  "kty": "oct",
+  "kid": "L9-eBkDrYHdPdXV_ymuzy_u9n3drkQcSw5pskrNl4pg",
+  "k": "WsTdZ2tjji2W36JN9vk9s2AYsvp8eYy1pBbKPgcSLL4",
+};
+
 export default async function openDataStore(cfg = {}) {
   if (!datastore) {
     datastore = await DataStore.open({

--- a/src/webextension/background/message-ports.js
+++ b/src/webextension/background/message-ports.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import openDataStore from "./datastore";
+import openDataStore, { DEFAULT_APP_KEY } from "./datastore";
 import getAccount, * as accounts from "./accounts";
 import updateBrowserAction from "./browser-action";
 import * as telemetry from "./telemetry";
@@ -57,7 +57,9 @@ export default function initializeMessagePorts() {
 
     case "initialize":
       return openDataStore().then(async (datastore) => {
-        await datastore.initialize();
+        await datastore.initialize({
+          appKey: DEFAULT_APP_KEY,
+        });
         // TODO: be more implicit on saving account info
         await accounts.saveAccount(browser.storage.local);
         await updateBrowserAction({datastore});
@@ -75,7 +77,7 @@ export default function initializeMessagePorts() {
 
         try {
           if (datastore.initialized && datastore.locked) {
-            await datastore.unlock();
+            await datastore.unlock(DEFAULT_APP_KEY);
           }
           await datastore.initialize({ appKey, salt, rebase: true });
           // FIXME: be more implicit on saving account info


### PR DESCRIPTION
Resolves #435 

Moves the `DEFAULT_APP_KEY` out of [datastore](/mozilla-lockbox/lockbox-datastore) to here.  This can land before or at the same time as the fix for mozilla-lockbox/lockbox-datastore#68.

Doing more requires a comprehensive solution to #426, and that's a much larger changeset than I think we're ready for.