### PR TITLE
Fix scrolling in management view

### DIFF
--- a/src/webextension/list/manage/components/app.css
+++ b/src/webextension/list/manage/components/app.css
@@ -2,24 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* The rules on `html` and `body` ensure that the body is always the full height
-   of the viewport at minimum, but that it can grow if the content is too long.
-   This ensures that absolutely-positioned elements can cover the entire
-   document (necessary for our dropdowns). */
-
-html,
 body {
-  display: flex;
-  min-height: 100%;
-}
-
-body,
-body > main {
-  flex: 1;
-}
-
-body {
-  position: relative;
   padding: 0;
   margin: 0;
   color: #0c0c0d;
@@ -27,8 +10,11 @@ body {
   font: caption;
   font-size: 13px;
   -moz-user-select: none;
+  overflow: hidden;
 }
 
+html,
+body,
 body > main,
 .app {
   height: 100%;
@@ -59,6 +45,7 @@ body > main,
   grid-column: 2;
   background-color: #f9f9fa;
   border-top: 1px solid #d1d1d2;
+  overflow: auto;
 }
 
 .filter {


### PR DESCRIPTION
Fixes #530 

I hate CSS. This mostly reverts the app.css changes from the dropdown patch but makes the main panel scroll if it overflows. Now, the <body> can never scroll because that would screw up clicking out of the dropdown. (This means that the minimum height for the management tab is something around 100px; anything less will cut stuff off.)

Note: I probably won't have much time to follow up on this since I am technically OoO now.