### PR TITLE
Ensure FxA account is stored always

### DIFF
--- a/src/webextension/background/accounts/index.js
+++ b/src/webextension/background/accounts/index.js
@@ -320,6 +320,8 @@ export class Account {
 let account;
 export default function getAccount() {
   if (!account) {
+    // eslint-disable-next-line no-console
+    console.warn("creating a default un-stored account instance!");
     account = new Account({});
   }
   return account;
@@ -336,6 +338,10 @@ export async function loadAccount(storage) {
       ...stored.account,
       storage,
     });
+  } else {
+    account = new Account({
+      storage,
+    });
   }
   return getAccount();
 }
@@ -350,8 +356,8 @@ export async function openAccount(storage) {
     console.log(`loaded account for (${account.mode.toString()}) '${account.uid || ""}'`);
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error(`loading account failed (fallback to empty GUEST): ${err.message}`);
-    account = getAccount();
+    console.error(`loading account failed: ${err.message}`);
+    throw err;
   }
 
   return account;

--- a/src/webextension/background/browser-action.js
+++ b/src/webextension/background/browser-action.js
@@ -60,8 +60,13 @@ export default async function updateBrowserAction({account = getAccount(), datas
     if (account.mode === accounts.GUEST) {
       // unlock on user's behalf ...
       // XXXX: is this a bad idea or terrible idea?
-      await datastore.unlock(DEFAULT_APP_KEY);
-      return installEntriesAction();
+      try {
+        await datastore.unlock(DEFAULT_APP_KEY);
+        return installEntriesAction();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log(`WARNING: datastore is in an inconsistent state.  Please reset and start again`);
+      }
     }
     // setup unlock popup
     return installPopup("unlock/index.html");

--- a/src/webextension/background/browser-action.js
+++ b/src/webextension/background/browser-action.js
@@ -65,7 +65,7 @@ export default async function updateBrowserAction({account = getAccount(), datas
         return installEntriesAction();
       } catch (err) {
         // eslint-disable-next-line no-console
-        console.log(`WARNING: datastore is in an inconsistent state.  Please reset and start again`);
+        console.log(`WARNING: datastore is in an inconsistent state.  You may need to reset and start again`);
       }
     }
     // setup unlock popup

--- a/src/webextension/background/datastore.js
+++ b/src/webextension/background/datastore.js
@@ -26,6 +26,10 @@ export const DEFAULT_APP_KEY = {
   "k": "WsTdZ2tjji2W36JN9vk9s2AYsvp8eYy1pBbKPgcSLL4",
 };
 
+export function clearDataStore() {
+  datastore = undefined;
+}
+
 export default async function openDataStore(cfg = {}) {
   if (!datastore) {
     datastore = await DataStore.open({

--- a/src/webextension/background/index.js
+++ b/src/webextension/background/index.js
@@ -14,7 +14,7 @@ openAccount(browser.storage.local).then(async (account) => {
       await datastore.unlock(DEFAULT_APP_KEY);
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.log(`WARNING: datastore is in an inconsistent state.  Please reset and start again`);
+      console.log(`WARNING: datastore is in an inconsistent state.`);
     }
   }
 

--- a/src/webextension/background/index.js
+++ b/src/webextension/background/index.js
@@ -10,7 +10,12 @@ import updateBrowserAction from "./browser-action";
 openAccount(browser.storage.local).then(async (account) => {
   let datastore = await openDataStore({ salt: account.uid });
   if (datastore.initialized && account.mode === GUEST) {
-    await datastore.unlock(DEFAULT_APP_KEY);
+    try {
+      await datastore.unlock(DEFAULT_APP_KEY);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(`WARNING: datastore is in an inconsistent state.  Please reset and start again`);
+    }
   }
 
   initializeMessagePorts();

--- a/src/webextension/background/message-ports.js
+++ b/src/webextension/background/message-ports.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import openDataStore, { DEFAULT_APP_KEY } from "./datastore";
+import openDataStore, { clearDataStore, DEFAULT_APP_KEY } from "./datastore";
 import getAccount, * as accounts from "./accounts";
 import updateBrowserAction from "./browser-action";
 import * as telemetry from "./telemetry";
@@ -115,8 +115,7 @@ export default function initializeMessagePorts() {
 
 
     case "signin":
-      return openDataStore().then(async (datastore) => {
-        const account = getAccount();
+      return Promise.resolve(getAccount()).then(async (account) => {
         let appKey = DEFAULT_APP_KEY;
         try {
           if (account.mode !== accounts.AUTHENTICATED) {
@@ -125,11 +124,15 @@ export default function initializeMessagePorts() {
           if (account.mode === accounts.AUTHENTICATED) {
             appKey = account.keys.get(accounts.APP_KEY_NAME);
           }
+
+          // XXXX: Find a better way to affect recovery
+          clearDataStore();
+          const datastore = await openDataStore({ salt: account.uid });
+
           await datastore.unlock(appKey);
           await updateBrowserAction({ datastore });
           telemetry.recordEvent("fxaSignin", "accounts");
         } catch (err) {
-          console.log(`signin failed: ${err.message}`);
           telemetry.recordEvent("fxaFailed", "accounts", { message: err.message });
           throw err;
         }

--- a/src/webextension/background/message-ports.js
+++ b/src/webextension/background/message-ports.js
@@ -81,7 +81,7 @@ export default function initializeMessagePorts() {
           await updateBrowserAction({ account, datastore });
           telemetry.recordEvent("fxaUpgrade", "accounts");
         } catch (err) {
-          telemetry.recordEvent("fxaFailed", "accounts", err.message);
+          telemetry.recordEvent("fxaFailed", "accounts", { message: err.message });
           throw err;
         }
 
@@ -107,15 +107,19 @@ export default function initializeMessagePorts() {
         openView("firstrun");
 
         return {};
+      }).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.log(`failed to reset: ${err.message}`);
+        throw err;
       });
 
 
     case "signin":
       return openDataStore().then(async (datastore) => {
         const account = getAccount();
-        let appKey;
+        let appKey = DEFAULT_APP_KEY;
         try {
-          if (account.mode === accounts.UNAUTHENTICATED) {
+          if (account.mode !== accounts.AUTHENTICATED) {
             await account.signIn();
           }
           if (account.mode === accounts.AUTHENTICATED) {
@@ -125,7 +129,8 @@ export default function initializeMessagePorts() {
           await updateBrowserAction({ datastore });
           telemetry.recordEvent("fxaSignin", "accounts");
         } catch (err) {
-          telemetry.recordEvent("fxaFailed", "accounts", err.message);
+          console.log(`signin failed: ${err.message}`);
+          telemetry.recordEvent("fxaFailed", "accounts", { message: err.message });
           throw err;
         }
 

--- a/test/unit/background/accounts-test.js
+++ b/test/unit/background/accounts-test.js
@@ -28,7 +28,7 @@ describe("background > accounts", () => {
 
   describe("loadAccount()", () => {
     it("with saved account", async () => {
-      const result = await accounts.loadAccount({
+      const mockStorage = {
         get: async () => ({
           account: {
             config: "dev-latest",
@@ -38,21 +38,25 @@ describe("background > accounts", () => {
             },
           },
         }),
-      });
+      };
+      const result = await accounts.loadAccount(mockStorage);
       expect(result.info).to.deep.equal({verified: true, uid: "1234"});
+      expect(result.storage).to.equal(mockStorage);
     });
 
     it("without saved account", async () => {
-      const result = await accounts.loadAccount({
+      const mockStorage = {
         get: async () => ({}),
-      });
+      };
+      const result = await accounts.loadAccount(mockStorage);
       expect(result.info).to.equal(undefined);
+      expect(result.storage).to.equal(mockStorage);
     });
   });
 
   describe("openAccount()", () => {
     it("with saved account", async () => {
-      const result = await accounts.openAccount({
+      const mockStorage = {
         get: async () => ({
           account: {
             config: "dev-latest",
@@ -62,24 +66,34 @@ describe("background > accounts", () => {
             },
           },
         }),
-      });
+      };
+      const result = await accounts.openAccount(mockStorage);
       expect(result.info).to.deep.equal({ verified: true, uid: "1234" });
+      expect(result.storage).to.equal(mockStorage);
     });
 
     it("without saved account", async () => {
-      const result = await accounts.openAccount({
+      const mockStorage = {
         get: async () => ({}),
-      });
+      };
+      const result = await accounts.openAccount(mockStorage);
       expect(result.info).to.equal(undefined);
+      expect(result.storage).to.equal(mockStorage);
     });
 
     it("with error", async () => {
-      const result = await accounts.openAccount({
+      const mockStorage = {
         get: async () => {
           throw new Error("test for failure");
         },
-      });
-      expect(result.info).to.equal(undefined);
+      };
+
+      try {
+        await accounts.openAccount(mockStorage);
+        expect(false, "unexpected success").to.be.ok;
+      } catch (err) {
+        expect(err.message).to.equal("test for failure");
+      }
     });
   });
 


### PR DESCRIPTION
Fixes #568 

The referenced failure is due to browser storage only applied if an account was stored, but not when starting fresh.  This takes steps to ensure the storage is applied whenever `loadAccount()` (which is called by `openAccount()` succeeds.