### PR TITLE
Set autoFocus on search filter input so it's focused immediately

### DIFF
--- a/src/webextension/widgets/filter-input.js
+++ b/src/webextension/widgets/filter-input.js
@@ -55,7 +55,8 @@ export default class FilterInput extends React.Component {
       <div className={finalClassName}>
         <input type="search" {...props} disabled={disabled}
                value={this.state.value}
-               onChange={(e) => this.updateValue(e.target.value)}/>
+               onChange={(e) => this.updateValue(e.target.value)}
+               autoFocus/>
         <Localized id="filter-input-clear">
           <button type="button" disabled={disabled}
                   onClick={() => this.updateValue("")}>


### PR DESCRIPTION
Resolves #573

I realize this is neither prioritized work nor are we agreed on what/how to address this, but having to tab or mouse to the search field 99% of the time I'm opening Lockbox (doorhanger _or_ manage list) really slows _my_ day-to-day usage.

Here's a one-line change to autofocus on the search field both in the doorhanger and the manage listing.


![autofocus](https://user-images.githubusercontent.com/49511/36803454-d0ef33fa-1c74-11e8-87d1-48327e0dd8c2.gif)

I figured figured a one line change wouldn't be _too_ problematic. I realize this could be abstracted into a property (so we can explicitly set it per use) but when looking at the latest designs, the search box is going to be the first element in the top right of the interface in both manage list and doorhanger so figure we just go ahead and drop the user in it without abstracting stuff too much (aka wait until we need it).

