### PR TITLE
Speed up branch and PR builds with Travis CI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ _aliases:
     language: node_js
     node_js: stable
 
+cache:
+  directories:
+    - node_modules
+
 sudo: required
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ _aliases:
 cache:
   directories:
     - node_modules
+cache: pip
 
 sudo: required
 jobs:


### PR DESCRIPTION
This is really a "PR to start a discussion" around a _hopefully_ 🤞 quick win to speed up our branch and PR builds: use Travis CI's caching to store `node_modules` ([read more on their blog](https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/) and [in the docs](https://docs.travis-ci.com/user/caching/#Fetching-and-storing-caches))

tldr: they will package up the `node_modules` directory and put it in S3, then pull it back down, per-branch and PR. If anything in the code changes the results, they get the updates and store that.

In some quick tests on my fork [seen here](https://docs.travis-ci.com/user/caching/#Fetching-and-storing-caches) I was able to shave off about ~1 minute per test during the `npm install` step (instead it just pulls down the assets and unpacks them, then does `npm install` to check for updates).

I'm just putting this out there in case @linuxwolf and/or @jimporter would find it useful. I acknowledge there may be some risk of dependencies getting wrong versions cached but in my test I was able to upgrade and downgrade a package and the cache was smart enough to know (from what I can tell).