### PR TITLE
Require python 3.6 in deploy stage so pip can install tornado

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ jobs:
         provider: pages
         on:
           branch: master
+          python: '3.6'
         skip_cleanup: true
         local_dir: site
         github_token: $GITHUB_TOKEN


### PR DESCRIPTION
We use pip install for mkdocs on the deploy stage for master

[Tornado 5.0](http://www.tornadoweb.org/en/latest/releases/v5.0.0.html) was released today which dropped support for older python versions.

I _think_ this will fix the PR build (that includes deploy) stage. Will wait and see if green. ✅ 