### PR TITLE
Move python runtime for deploy stage out of 'on' requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,12 @@ jobs:
     - stage: deploy
       if: branch = master
       <<: *node
+      python: '3.6'
       script: skip
       deploy:
         provider: pages
         on:
           branch: master
-          python: '3.6'
         skip_cleanup: true
         local_dir: site
         github_token: $GITHUB_TOKEN


### PR DESCRIPTION
I think I made a dumb mistake at #613 and "required" python in the wrong way. Right now master deploys are skipping the pages deploy because this is in "on" (check if its in the runtime vs just set the runtime).