### PR TITLE
[WIP] Parse URLs when filtering

### DIFF
--- a/src/webextension/list/popup/index.js
+++ b/src/webextension/list/popup/index.js
@@ -26,7 +26,7 @@ browser.tabs.query({ active: true, currentWindow: true }).then((result) => {
   const validProtocols = ["http:", "https:"];
   const url = new URL(result[0].url);
   if (validProtocols.includes(url.protocol)) {
-    store.dispatch(filterItems(url.hostname));
+    store.dispatch(filterItems(url.protocol + "//" + url.host));
   }
 });
 


### PR DESCRIPTION
This is still very WIP, but it should give an idea of how I plan to pass the data around. The general idea is that when the popup opens, we fill in the protocol, host, and port (if the port is default, it's implicitly defined by the protocol), which then gets passed to the filter code.

The filter code rebuilds a URL object and tries to match it to URL objects for the origins of each item. Origins are allowed to omit their protocol, in which case we treat them as HTTPS. If the search query omits *its* protocol (this will only happen when the user is typing in the filter themselves), we just do a string comparison. This way, you only have to type part of a URL (e.g. "goo" for "https://www.google.com") to filter the results down when you're searching manually.

Up next, I plan to make the matching on valid URLs work closer to our plan.