### PR TITLE
Create a classNames() function to handle building className props more easily

### DIFF
--- a/src/webextension/common.js
+++ b/src/webextension/common.js
@@ -10,3 +10,7 @@ export function makeItemSummary(item) {
     username: item.entry.username,
   };
 }
+
+export function classNames(classNames) {
+  return classNames.filter((i) => i).join(" ");
+}

--- a/src/webextension/list/components/item-list.js
+++ b/src/webextension/list/components/item-list.js
@@ -5,6 +5,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../../common";
 import ItemSummary from "./item-summary";
 import ScrollingList from "../../widgets/scrolling-list";
 
@@ -12,17 +13,15 @@ import styles from "./item-list.css";
 
 export default function ItemList({items, itemClassName, verbose, onCopy,
                                   ...props}) {
-  const verboseClass = verbose ? ` ${styles.verbose}` : "";
-  const finalItemClassName = (
-    `${styles.item}${verboseClass} ${itemClassName}`
-  ).trimRight();
-
   return (
-    <ScrollingList className={styles.itemList} itemClassName={finalItemClassName} data={items} styledItems={false} {...props}>
+    <ScrollingList {...props} className={styles.itemList}
+                   itemClassName={classNames([
+                     styles.item, verbose && styles.verbose, itemClassName,
+                   ])} data={items} styledItems={false}>
       {({id, title, username}) => {
         return (
-          <ItemSummary className={styles.itemSummary} id={id} title={title} username={username}
-                       verbose={verbose} onCopy={onCopy}/>
+          <ItemSummary className={styles.itemSummary} id={id} title={title}
+                       username={username} verbose={verbose} onCopy={onCopy}/>
         );
       }}
     </ScrollingList>

--- a/src/webextension/list/components/item-summary.js
+++ b/src/webextension/list/components/item-summary.js
@@ -6,6 +6,7 @@ import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../../common";
 import { NEW_ITEM_ID } from "../common";
 import CopyToClipboardButton from "../../widgets/copy-to-clipboard-button";
 
@@ -62,10 +63,9 @@ export default function ItemSummary({className, id, title, username, verbose,
   const idModifier = id === NEW_ITEM_ID ? "new-" : "";
   const titleId = `item-summary-${idModifier}title`;
   const usernameId = `item-summary-${idModifier}username`;
-  const finalClassName = `${styles.itemSummary} ${className}`.trimRight();
   return (
     <div>
-      <div className={finalClassName}>
+      <div className={classNames([styles.itemSummary, className])}>
         <Localized id={titleId} $title={trimmedTitle}
                    $length={trimmedTitle.length}>
           <div className={styles.title}>no tITLe</div>

--- a/src/webextension/list/containers/item-filter.js
+++ b/src/webextension/list/containers/item-filter.js
@@ -13,7 +13,7 @@ import FilterInput from "../../widgets/filter-input";
 function ItemFilter({inputRef, ...props}) {
   return (
     <Localized id="item-filter">
-      <FilterInput placeholder="fILTEr…" ref={inputRef} {...props}/>
+      <FilterInput {...props} placeholder="fILTEr…" ref={inputRef}/>
     </Localized>
   );
 }

--- a/src/webextension/list/manage/components/account-summary.js
+++ b/src/webextension/list/manage/components/account-summary.js
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import Modal from "react-modal";
 
+import { classNames } from "../../../common";
 import { Link } from "../../../widgets/link";
 
 import styles from "./account-summary.css";
@@ -39,7 +40,7 @@ export function AccountSummaryDropdown({isOpen, onClose, onClickAccount,
       <ul>
         <li>
           <Localized id="account-summary-account">
-            <Link className={`${styles.dropdownLink} ${styles.account}`}
+            <Link className={classNames([styles.dropdownLink, styles.account])}
                   onClick={() => { onClickAccount(); onClose(); }}>
               aCCOUNt
             </Link>
@@ -47,7 +48,7 @@ export function AccountSummaryDropdown({isOpen, onClose, onClickAccount,
         </li>
         <li>
           <Localized id="account-summary-options">
-            <Link className={`${styles.dropdownLink} ${styles.options}`}
+            <Link className={classNames([styles.dropdownLink, styles.options])}
                   onClick={() => { onClickOptions(); onClose(); }}>
               oPTIONs
             </Link>
@@ -55,7 +56,7 @@ export function AccountSummaryDropdown({isOpen, onClose, onClickAccount,
         </li>
         <li>
           <Localized id="account-summary-signout">
-            <Link className={`${styles.dropdownLink} ${styles.signout}`}
+            <Link className={classNames([styles.dropdownLink, styles.signout])}
                   onClick={() => { onClickSignout(); onClose(); }}>
               sIGn oUt
             </Link>
@@ -104,9 +105,8 @@ export default class AccountSummary extends React.Component {
       <div>
         <AccountSummaryButton displayName={displayName} avatar={avatar}
                               onClick={() => this.openDropdown()}/>
-        <AccountSummaryDropdown isOpen={showDropdown}
-                                onClose={() => this.closeDropdown()}
-                                {...props}/>
+        <AccountSummaryDropdown {...props} isOpen={showDropdown}
+                                onClose={() => this.closeDropdown()}/>
       </div>
     );
   }

--- a/src/webextension/list/manage/components/edit-item-details.js
+++ b/src/webextension/list/manage/components/edit-item-details.js
@@ -6,6 +6,7 @@ import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../../../common";
 import Button from "../../../widgets/button";
 import Toolbar from "../../../widgets/toolbar";
 import { EditItemFields } from "../../components/item-fields";
@@ -61,7 +62,7 @@ export default class EditItemDetails extends React.Component {
     const newItem = itemId === null;
 
     return (
-      <form className={`${styles.itemDetails} ${styles.editing}`}
+      <form className={classNames([styles.itemDetails, styles.editing])}
             onSubmit={(e) => {
               e.preventDefault();
               onSave(this.state);

--- a/src/webextension/widgets/button.js
+++ b/src/webextension/widgets/button.js
@@ -5,6 +5,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./button.css";
 
 const THEME_CLASS_NAME = {
@@ -44,15 +46,11 @@ export default class Button extends React.Component {
 
   render() {
     const {className, theme, size, ...props} = this.props;
-    const themeClass = THEME_CLASS_NAME[theme];
-    const sizeClass = SIZE_CLASS_NAME[size];
-    const finalClassName = (
-      `${styles.button} ${themeClass} ${sizeClass} ${className}`
-    ).trimRight();
-
     return (
-      <button className={finalClassName} {...props}
-              ref={(element) => this.buttonElement = element}/>
+      <button {...props} className={classNames([
+                styles.button, THEME_CLASS_NAME[theme],
+                SIZE_CLASS_NAME[size], className,
+              ])} ref={(element) => this.buttonElement = element}/>
     );
   }
 }

--- a/src/webextension/widgets/copy-to-clipboard-button.js
+++ b/src/webextension/widgets/copy-to-clipboard-button.js
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import copy from "copy-to-clipboard";
 
+import { classNames } from "../common";
 import Button from "./button";
 import Stack from "./stack";
 
@@ -58,9 +59,6 @@ export default class CopyToClipboardButton extends React.Component {
   render() {
     let {title, children, className, buttonClassName} = this.props;
     const selectedIndex = this.state.copied ? 1 : 0;
-    const finalClassName = (
-      `${styles.copyButton} ${buttonClassName}`
-    ).trimRight();
 
     if (!children) {
       children = (
@@ -71,8 +69,9 @@ export default class CopyToClipboardButton extends React.Component {
     }
     return (
       <Stack stretch selectedIndex={selectedIndex} className={className}>
-        <Button theme="ghost" className={finalClassName} title={title}
-                onClick={() => this.handleCopy()}>
+        <Button theme="ghost" className={classNames([
+                  styles.copyButton, buttonClassName,
+                ])} title={title} onClick={() => this.handleCopy()}>
           {children}
         </Button>
         <Localized id="copy-to-clipboard-copied">

--- a/src/webextension/widgets/dialog-box.js
+++ b/src/webextension/widgets/dialog-box.js
@@ -52,8 +52,8 @@ export default class DialogBox extends React.Component {
             }
 
             return (
-              <Button key={i} onClick={() => { onClick(i); onClose(); }}
-                      theme={theme} {...extraProps}>
+              <Button {...extraProps} key={i} theme={theme}
+                      onClick={() => { onClick(i); onClose(); }}>
                 {label}
               </Button>
             );
@@ -67,12 +67,11 @@ export default class DialogBox extends React.Component {
 export function ConfirmDialog({confirmLabel, cancelLabel, theme, onConfirm,
                                ...props}) {
   return (
-    <DialogBox buttons={[
+    <DialogBox {...props} buttons={[
                  {label: confirmLabel, theme},
                  {label: cancelLabel},
                ]}
-               onClick={(i) => { if (i === 0) { onConfirm(); } }}
-               {...props}/>
+               onClick={(i) => { if (i === 0) { onConfirm(); } }}/>
   );
 }
 

--- a/src/webextension/widgets/field-text.js
+++ b/src/webextension/widgets/field-text.js
@@ -5,13 +5,15 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./input.css";
 
 export default function FieldText({className, monospace, ...props}) {
-  const mono = monospace ? ` ${styles.monospace}` : "";
-  const finalClassName = `${styles.fieldText}${mono} ${className}`.trimRight();
   return (
-    <span className={finalClassName} {...props}/>
+    <span {...props} className={classNames([
+            styles.fieldText, monospace && styles.monospace, className,
+          ])}/>
   );
 }
 

--- a/src/webextension/widgets/filter-input.js
+++ b/src/webextension/widgets/filter-input.js
@@ -6,6 +6,8 @@ import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./input.css";
 
 export default class FilterInput extends React.Component {
@@ -53,16 +55,16 @@ export default class FilterInput extends React.Component {
   render() {
     // eslint-disable-next-line no-unused-vars
     const {className, onChange, value, disabled, ...props} = this.props;
-    const disabledClass = disabled ? ` ${styles.disabled}` : "";
-    const finalClassName = (
-      `${styles.filter} ${styles.inputWrapper}${disabledClass} ${className}`
-    ).trimRight();
 
     return (
-      <div className={finalClassName}>
-        <input type="search" disabled={disabled} value={this.state.value}
+      <div className={classNames([
+             styles.filter, styles.inputWrapper, disabled && styles.disabled,
+             className,
+           ])}>
+        <input {...props} type="search" disabled={disabled}
+               value={this.state.value}
                onChange={(e) => this.updateValue(e.target.value)}
-               ref={(element) => this.inputElement = element} {...props}/>
+               ref={(element) => this.inputElement = element}/>
         <Localized id="filter-input-clear">
           <button type="button" title="cLEAr" disabled={disabled}
                   onClick={() => this.updateValue("")}/>

--- a/src/webextension/widgets/input.js
+++ b/src/webextension/widgets/input.js
@@ -5,6 +5,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./input.css";
 
 export default class Input extends React.Component {
@@ -31,11 +33,10 @@ export default class Input extends React.Component {
 
   render() {
     const {className, monospace, ...props} = this.props;
-    const mono = monospace ? ` ${styles.monospace}` : "";
-    const finalClassName = `${styles.input}${mono} ${className}`.trimRight();
     return (
-      <input className={finalClassName} {...props}
-             ref={(element) => this.inputElement = element}/>
+      <input {...props} className={classNames([
+               styles.input, monospace && styles.monospace, className,
+             ])} ref={(element) => this.inputElement = element}/>
     );
   }
 }

--- a/src/webextension/widgets/label-text.js
+++ b/src/webextension/widgets/label-text.js
@@ -5,12 +5,13 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./input.css";
 
 export default function LabelText({className, ...props}) {
-  const finalClassName = `${styles.labelText} ${className}`.trimRight();
   return (
-    <span className={finalClassName} {...props}/>
+    <span {...props} className={classNames([styles.labelText, className])}/>
   );
 }
 

--- a/src/webextension/widgets/link.js
+++ b/src/webextension/widgets/link.js
@@ -5,6 +5,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./link.css";
 
 export class Link extends React.Component {
@@ -25,7 +27,7 @@ export class Link extends React.Component {
   }
 
   get baseClassName() {
-    return `${styles.link}`;
+    return styles.link;
   }
 
   focus() {
@@ -34,11 +36,10 @@ export class Link extends React.Component {
 
   render() {
     const {className, role, onClick, children, ...props} = this.props;
-    const finalClassName = `${this.baseClassName} ${className}`.trimRight();
     return (
-      <button ref={(element) => this.linkElement = element}
-              {...props} className={finalClassName} role={role}
-              onClick={onClick}>
+      <button {...props} role={role}
+              className={classNames([this.baseClassName, className])}
+              onClick={onClick} ref={(element) => this.linkElement = element}>
         {children}
       </button>
     );
@@ -51,6 +52,6 @@ export class Link extends React.Component {
 
 export class ExternalLink extends Link {
   get baseClassName() {
-    return `${styles.link} ${styles.external}`;
+    return classNames([styles.link, styles.external]);
   }
 }

--- a/src/webextension/widgets/panel.js
+++ b/src/webextension/widgets/panel.js
@@ -6,16 +6,16 @@ import { Localized } from "fluent-react";
 import React from "react";
 import PropTypes from "prop-types";
 
+import { classNames } from "../common";
 import Button from "./button";
 
 import buttonStyles from "./button.css";
 import styles from "./panel.css";
 
 export function PanelHeader({className, onBack, children}) {
-  const finalClassName = `${styles.panelHeader} ${className}`.trimRight();
   const imgSrc = browser.extension.getURL("/icons/arrowhead-left-16.svg");
   return (
-    <header className={finalClassName}>
+    <header className={classNames([styles.panelHeader, className])}>
       {onBack ? (
         <Button theme="ghost" size="micro" onClick={onBack}>
           <Localized id="panel-back-button">
@@ -39,9 +39,8 @@ PanelHeader.defaultProps = {
 };
 
 export function PanelBody({className, children}) {
-  const finalClassName = `${styles.panelBody} ${className}`.trimRight();
   return (
-    <main className={finalClassName}>
+    <main className={classNames([styles.panelBody, className])}>
       {children}
     </main>
   );
@@ -57,9 +56,8 @@ PanelBody.defaultProps = {
 };
 
 export function PanelFooter({className, children}) {
-  const finalClassName = `${styles.panelFooter} ${className}`.trimRight();
   return (
-    <footer className={finalClassName}>
+    <footer className={classNames([styles.panelFooter, className])}>
       {children}
     </footer>
   );
@@ -100,23 +98,18 @@ export class PanelFooterButton extends React.Component {
 
   render() {
     const {theme, className, ...props} = this.props;
-    const themeClass = THEME_CLASS_NAME[theme];
-    const finalClassName = (
-      `${buttonStyles.button} ${styles.panelFooterButton} ${themeClass} ` +
-      `${className}`
-    ).trimRight();
-
     return (
-      <button className={finalClassName} {...props}
-              ref={(element) => this.buttonElement = element}/>
+      <button {...props} className={classNames([
+                buttonStyles.button, styles.panelFooterButton,
+                THEME_CLASS_NAME[theme], className,
+              ])} ref={(element) => this.buttonElement = element}/>
     );
   }
 }
 
 export default function Panel({className, children}) {
-  const finalClassName = `${styles.panel} ${className}`.trimRight();
   return (
-    <article className={finalClassName}>
+    <article className={classNames([styles.panel, className])}>
       {children}
     </article>
   );

--- a/src/webextension/widgets/password-input.js
+++ b/src/webextension/widgets/password-input.js
@@ -6,6 +6,7 @@ import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
 import Stack from "./stack";
 
 import styles from "./input.css";
@@ -46,25 +47,26 @@ export default class PasswordInput extends React.Component {
   render() {
     const {className, monospace, disabled, ...props} = this.props;
     const {showPassword} = this.state;
-    const disabledClass = disabled ? ` ${styles.disabled}` : "";
-    const finalClassName = (
-      `${styles.password} ${styles.inputWrapper}${disabledClass} ${className}`
-    ).trimRight();
     const selectedIndex = showPassword ? 1 : 0;
 
     return (
-      <div className={finalClassName}>
-        <input className={monospace ? styles.monospace : ""} disabled={disabled}
-               type={showPassword ? "text" : "password"}
-               ref={(element) => this.inputElement = element} {...props}/>
+      <div className={classNames([
+             styles.password, styles.inputWrapper, disabled && styles.disabled,
+             className,
+           ])}>
+        <input {...props} type={showPassword ? "text" : "password"}
+               className={monospace ? styles.monospace : ""} disabled={disabled}
+               ref={(element) => this.inputElement = element}/>
         <Stack stretch selectedIndex={selectedIndex}>
           <Localized id="password-input-show">
-            <button className={styles.showBtn} type="button" title="sHOw" disabled={disabled}
-                    onClick={() => this.showPassword(true)}></button>
+            <button type="button" className={styles.showBtn} title="sHOw"
+                    disabled={disabled}
+                    onClick={() => this.showPassword(true)}/>
           </Localized>
           <Localized id="password-input-hide">
-            <button className={styles.hideBtn} type="button" title="hIDe" disabled={disabled}
-                    onClick={() => this.showPassword(false)}></button>
+            <button type="button" className={styles.hideBtn} title="hIDe"
+                    disabled={disabled}
+                    onClick={() => this.showPassword(false)}/>
           </Localized>
         </Stack>
       </div>

--- a/src/webextension/widgets/scrolling-list.js
+++ b/src/webextension/widgets/scrolling-list.js
@@ -5,6 +5,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./scrolling-list.css";
 
 export default class ScrollingList extends React.Component {
@@ -116,15 +118,15 @@ export default class ScrollingList extends React.Component {
   render() {
     const { className, itemClassName, styledItems, children, data, tabIndex,
             selected } = this.props;
-    const finalClassName = `${styles.scrollingList} ${className}`.trimRight();
-    const finalItemClassName = styledItems ?
-          `${styles.styledItem} ${itemClassName}`.trimRight() :
-          itemClassName;
+    const finalItemClassName = classNames([
+      styledItems && styles.styledItem, itemClassName,
+    ]);
 
     return (
-      <ul tabIndex={tabIndex} className={finalClassName}
-          ref={(element) => this._rootElement = element}
-          onKeyDown={(e) => this.handleKeyDown(e)}>
+      <ul className={classNames([
+            styles.scrollingList, className,
+          ])} tabIndex={tabIndex} onKeyDown={(e) => this.handleKeyDown(e)}
+          ref={(element) => this._rootElement = element}>
         {data.map((item) => {
           let props = {
             onMouseDown: (e) => this.handleMouseDown(e, item.id),
@@ -138,7 +140,7 @@ export default class ScrollingList extends React.Component {
           }
 
           return (
-            <li key={item.id} {...props}>
+            <li {...props} key={item.id}>
               {children(item)}
             </li>
           );

--- a/src/webextension/widgets/stack.js
+++ b/src/webextension/widgets/stack.js
@@ -5,6 +5,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./stack.css";
 
 export default class Stack extends React.Component {
@@ -25,20 +27,17 @@ export default class Stack extends React.Component {
 
   render() {
     const {children, selectedIndex, stretch, ...props} = this.props;
-    const stretchClass = stretch ? ` ${styles.stretch}` : "";
-    const innerClassName = `${styles.stack}${stretchClass}`;
-
     return (
       <section {...props}>
-        <div className={innerClassName}>
+        <div className={classNames([styles.stack, stretch && styles.stretch])}>
           {React.Children.map(children, (child, i) => {
-            const props = {};
+            const extraProps = {};
             if (i === selectedIndex) {
-              props["data-selected"] = true;
+              extraProps["data-selected"] = true;
             }
 
             return (
-              <span className={styles.stackItem} key={i} {...props}>
+              <span {...extraProps} className={styles.stackItem} key={i}>
                 {child}
               </span>
             );

--- a/src/webextension/widgets/text-area.js
+++ b/src/webextension/widgets/text-area.js
@@ -5,6 +5,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./text-area.css";
 
 export default class TextArea extends React.Component {
@@ -31,9 +33,9 @@ export default class TextArea extends React.Component {
 
   render() {
     const {className, ...props} = this.props;
-    const finalClassName = `${styles.textArea} ${className}`.trimRight();
     return (
-      <textarea className={finalClassName} {...props}
+      <textarea {...props}
+                className={classNames([styles.textArea, className])}
                 ref={(element) => this.textAreaElement = element}/>
     );
   }

--- a/src/webextension/widgets/toolbar.js
+++ b/src/webextension/widgets/toolbar.js
@@ -5,12 +5,13 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { classNames } from "../common";
+
 import styles from "./toolbar.css";
 
 export default function Toolbar({className, children}) {
-  const finalClassName = `${styles.toolbar} ${className}`.trimRight();
   return (
-    <menu className={finalClassName}>
+    <menu className={classNames([styles.toolbar, className])}>
       {children}
     </menu>
   );
@@ -26,9 +27,8 @@ Toolbar.defaultProps = {
 };
 
 export function ToolbarSpace({className}) {
-  const finalClassName = `${styles.toolbarSpace} ${className}`.trimRight();
   return (
-    <span className={finalClassName}/>
+    <span className={classNames([styles.toolbarSpace, className])}/>
   );
 }
 

--- a/test/unit/mocks/l10n.js
+++ b/test/unit/mocks/l10n.js
@@ -16,7 +16,7 @@ function* generateMessages() {
 
 export function MockLocalizationProvider(props) {
   return (
-    <LocalizationProvider messages={generateMessages()} {...props}/>
+    <LocalizationProvider {...props} messages={generateMessages()}/>
   );
 }
 


### PR DESCRIPTION
This is effectively a simplified version of the npm `classnames` package. This commit also moves `{...props}` to the beginning of our list of applied props so that it's no longer possible to accidentally overwrite internal props.

This is a fairly big diff, but it's pretty simple, and should make it easier to apply our CSS class names. (I'm doing this now because I've been finding it an issue while working on the breadcrumbs PR.)