### PR TITLE
Updated CODEOWNERS to explicitly assign integration test ownership

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -2,24 +2,27 @@
 # https://help.github.com/articles/about-codeowners/
 
 # integration tests and related config are maintained by PI
-/requirements/      @mozilla-lockbox/product-integrity
-/test/integration/  @mozilla-lockbox/product-integrity
-/.pyup.ini          @mozilla-lockbox/product-integrity
-/setup.cfg          @mozilla-lockbox/product-integrity
-/tox.ini            @mozilla-lockbox/product-integrity
+/requirements/          @mozilla-lockbox/product-integrity
+/test/integration/      @mozilla-lockbox/product-integrity
+/.pyup.ini              @mozilla-lockbox/product-integrity
+/setup.cfg              @mozilla-lockbox/product-integrity
+/tox.ini                @mozilla-lockbox/product-integrity
 
 
 # unit tests and related config are maintained by engineering
-/test/unit/         @mozilla-lockbox/desktop-engineering
-/test/*             @mozilla-lockbox/desktop-engineering
+/test/unit/             @mozilla-lockbox/desktop-engineering
+/test/*                 @mozilla-lockbox/desktop-engineering
 
 # source code and docs are maintained by engineering
-/src/               @mozilla-lockbox/desktop-engineering
-/docs/              @mozilla-lockbox/desktop-engineering
+/src/                   @mozilla-lockbox/desktop-engineering
+/docs/                  @mozilla-lockbox/desktop-engineering
+
+# release notes are maintained by the product owners
+/docs/release-notes.md  @mozilla-lockbox/product
 
 # include Flod for l10n string changes
 # @todo uncomment below after initial string freeze
 #src/webextension/locales/en-US/*.ftl    @flodolo
 
 # otherwise, everything is to be reviewed by the desktop team
-*                   @mozilla-lockbox/desktop-engineering
+*                       @mozilla-lockbox/desktop-engineering

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,15 +1,18 @@
 # lockbox-extension code owners
 # https://help.github.com/articles/about-codeowners/
 
-# tests should also be reviewed by @m8ttyB
-/test/    @jimporter @m8ttyB
+# integration tests are maintained by PI
+/test/integration/  @mozilla-lockbox/product-integrity 
+/requirements/      @mozilla-lockbox/product-integrity 
 
-# docs are shepherded by @devinreams
-/docs/    @jimporter @devinreams
+# source code and unit tests are maintained by engineering
+/src/               @mozilla-lockbox/desktop-engineering
+/test/unit/         @mozilla-lockbox/desktop-engineering
+/docs/              @mozilla-lockbox/desktop-engineering
 
 # include Flod for l10n string changes
 # @todo uncomment below after initial string freeze
 #src/webextension/locales/en-US/*.ftl    @flodolo
 
-# otherwise, everything is to be reviewed by @jimporter
-*         @jimporter
+# otherwise, everything is to be reviewed by the desktop team
+*                   @mozilla-lockbox/desktop-engineering

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -2,27 +2,32 @@
 # https://help.github.com/articles/about-codeowners/
 
 # integration tests and related config are maintained by PI
-/requirements/          @mozilla-lockbox/product-integrity
-/test/integration/      @mozilla-lockbox/product-integrity
-/.pyup.ini              @mozilla-lockbox/product-integrity
-/setup.cfg              @mozilla-lockbox/product-integrity
-/tox.ini                @mozilla-lockbox/product-integrity
+/requirements/              @mozilla-lockbox/product-integrity
+/test/integration/          @mozilla-lockbox/product-integrity
+/.pyup.ini                  @mozilla-lockbox/product-integrity
+/setup.cfg                  @mozilla-lockbox/product-integrity
+/tox.ini                    @mozilla-lockbox/product-integrity
 
+# test plans are maintained by PI
+/docs/developer/test-plan*  @mozilla-lockbox/product-integrity
+
+# metrics docs are maintained by Leif
+/docs/metrics.md            @irrationalagent 
 
 # unit tests and related config are maintained by engineering
-/test/unit/             @mozilla-lockbox/desktop-engineering
-/test/                  @mozilla-lockbox/desktop-engineering
+/test/unit/                 @mozilla-lockbox/desktop-engineering
+/test/                      @mozilla-lockbox/desktop-engineering
 
-# source code and docs are maintained by engineering
-/src/                   @mozilla-lockbox/desktop-engineering
-/docs/                  @mozilla-lockbox/desktop-engineering
+# source code and all other docs are maintained by engineering
+/src/                       @mozilla-lockbox/desktop-engineering
+/docs/                      @mozilla-lockbox/desktop-engineering
 
 # release notes are maintained by the product owners
-/docs/release-notes.md  @mozilla-lockbox/product
+/docs/release-notes.md      @mozilla-lockbox/product
 
 # include Flod for l10n string changes
 # @todo uncomment below after initial string freeze
 #src/webextension/locales/en-US/*.ftl    @flodolo
 
 # otherwise, everything is to be reviewed by the desktop team
-*                       @mozilla-lockbox/desktop-engineering
+*                           @mozilla-lockbox/desktop-engineering

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -11,7 +11,7 @@
 
 # unit tests and related config are maintained by engineering
 /test/unit/             @mozilla-lockbox/desktop-engineering
-/test/*                 @mozilla-lockbox/desktop-engineering
+/test/                  @mozilla-lockbox/desktop-engineering
 
 # source code and docs are maintained by engineering
 /src/                   @mozilla-lockbox/desktop-engineering

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -8,9 +8,13 @@
 /setup.cfg          @mozilla-lockbox/product-integrity
 /tox.ini            @mozilla-lockbox/product-integrity
 
-# source code and unit tests are maintained by engineering
-/src/               @mozilla-lockbox/desktop-engineering
+
+# unit tests and related config are maintained by engineering
 /test/unit/         @mozilla-lockbox/desktop-engineering
+/test/*             @mozilla-lockbox/desktop-engineering
+
+# source code and docs are maintained by engineering
+/src/               @mozilla-lockbox/desktop-engineering
 /docs/              @mozilla-lockbox/desktop-engineering
 
 # include Flod for l10n string changes

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,9 +1,12 @@
 # lockbox-extension code owners
 # https://help.github.com/articles/about-codeowners/
 
-# integration tests are maintained by PI
-/test/integration/  @mozilla-lockbox/product-integrity 
-/requirements/      @mozilla-lockbox/product-integrity 
+# integration tests and related config are maintained by PI
+/requirements/      @mozilla-lockbox/product-integrity
+/test/integration/  @mozilla-lockbox/product-integrity
+/.pyup.ini          @mozilla-lockbox/product-integrity
+/setup.cfg          @mozilla-lockbox/product-integrity
+/tox.ini            @mozilla-lockbox/product-integrity
 
 # source code and unit tests are maintained by engineering
 /src/               @mozilla-lockbox/desktop-engineering


### PR DESCRIPTION
@jimporter @m8ttyB As proposed and discussed via email.

Here's how I believe you'd want it to look in GitHub reviews, themselves...