### PR TITLE
Hide "clear" button on filter when there is no input

### DIFF
--- a/src/webextension/widgets/filter-input.js
+++ b/src/webextension/widgets/filter-input.js
@@ -67,7 +67,7 @@ export default class FilterInput extends React.Component {
                ref={(element) => this.inputElement = element}/>
         <Localized id="filter-input-clear">
           <button type="button" title="cLEAr"
-                  disabled={disabled ? disabled : !this.state.value}
+                  disabled={disabled || !this.state.value}
                   onClick={() => this.updateValue("")}/>
         </Localized>
       </div>

--- a/src/webextension/widgets/filter-input.js
+++ b/src/webextension/widgets/filter-input.js
@@ -66,7 +66,8 @@ export default class FilterInput extends React.Component {
                onChange={(e) => this.updateValue(e.target.value)}
                ref={(element) => this.inputElement = element}/>
         <Localized id="filter-input-clear">
-          <button type="button" title="cLEAr" disabled={!this.state.value}
+          <button type="button" title="cLEAr"
+                  disabled={disabled ? disabled : !this.state.value}
                   onClick={() => this.updateValue("")}/>
         </Localized>
       </div>

--- a/src/webextension/widgets/filter-input.js
+++ b/src/webextension/widgets/filter-input.js
@@ -66,7 +66,7 @@ export default class FilterInput extends React.Component {
                onChange={(e) => this.updateValue(e.target.value)}
                ref={(element) => this.inputElement = element}/>
         <Localized id="filter-input-clear">
-          <button type="button" title="cLEAr" disabled={disabled}
+          <button type="button" title="cLEAr" disabled={!this.state.value}
                   onClick={() => this.updateValue("")}/>
         </Localized>
       </div>

--- a/src/webextension/widgets/input.css
+++ b/src/webextension/widgets/input.css
@@ -153,6 +153,10 @@ input::placeholder {
   height: 100%;
 }
 
+.filter button[disabled] {
+  display: none;
+}
+
 .filter button::before {
   background-image: url(/icons/clear.svg);
   background-repeat: no-repeat;

--- a/test/unit/widgets/filter-input-test.js
+++ b/test/unit/widgets/filter-input-test.js
@@ -31,6 +31,7 @@ describe("widgets > <FilterInput/>", () => {
       <FilterInput value="some text" disabled={true}/>
     );
     expect(wrapper.find("input")).to.have.prop("disabled", true);
+    expect(wrapper.find("button")).to.have.prop("disabled", true);
     expect(wrapper.childAt(0).prop("className")).to.match(
       /^\S+filter\S+ \S+input-wrapper\S+ \S+disabled\S+$/
     );

--- a/test/unit/widgets/filter-input-test.js
+++ b/test/unit/widgets/filter-input-test.js
@@ -31,9 +31,19 @@ describe("widgets > <FilterInput/>", () => {
       <FilterInput value="some text" disabled={true}/>
     );
     expect(wrapper.find("input")).to.have.prop("disabled", true);
-    expect(wrapper.find("button")).to.have.prop("disabled", true);
     expect(wrapper.childAt(0).prop("className")).to.match(
       /^\S+filter\S+ \S+input-wrapper\S+ \S+disabled\S+$/
+    );
+  });
+
+  it("render disabled button if no filter value", () => {
+    const wrapper = mountWithL10n(
+      <FilterInput value="" disabled={false}/>
+    );
+    expect(wrapper.find("input")).to.have.prop("disabled", false);
+    expect(wrapper.find("button")).to.have.prop("disabled", true);
+    expect(wrapper.childAt(0).prop("className")).to.match(
+      /^\S+filter\S+ \S+input-wrapper\S+$/
     );
   });
 


### PR DESCRIPTION
Fixes #622 

This changes the styles and checks the state so that the clear ❌ button does not show on the search/filter input until there is actually text in the field.

![hide-search-button](https://user-images.githubusercontent.com/49511/37673155-22b4a718-2c35-11e8-9797-eb506e0d8a01.gif)

@jimporter I think this is the right way to check both for the input value _and_ inherit the entire form's `disabled` prop...